### PR TITLE
added support for zero-width-joiner and ansi escape sequences

### DIFF
--- a/include/unicode/display_width.hpp
+++ b/include/unicode/display_width.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef UNICODE_DISPLAY_WIDTH_H
+#define UNICODE_DISPLAY_WIDTH_H
 #include <clocale>
 #include <codecvt>
 #include <cstdlib>
@@ -342,3 +343,4 @@ inline int display_width(const std::wstring& input) {
 }
 
 }
+#endif // UNICODE_DISPLAY_WIDTH_H

--- a/test/doctest.hpp
+++ b/test/doctest.hpp
@@ -4,14 +4,14 @@
 //
 // doctest.h - the lightest feature-rich C++ single-header testing framework for unit tests and TDD
 //
-// Copyright (c) 2016-2019 Viktor Kirilov
+// Copyright (c) 2016-2021 Viktor Kirilov
 //
 // Distributed under the MIT Software License
 // See accompanying file LICENSE.txt or copy at
 // https://opensource.org/licenses/MIT
 //
 // The documentation can be found at the library's page:
-// https://github.com/onqtam/doctest/blob/master/doc/markdown/readme.md
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
 //
 // =================================================================================================
 // =================================================================================================
@@ -47,9 +47,17 @@
 // =================================================================================================
 
 #define DOCTEST_VERSION_MAJOR 2
-#define DOCTEST_VERSION_MINOR 3
-#define DOCTEST_VERSION_PATCH 5
-#define DOCTEST_VERSION_STR "2.3.5"
+#define DOCTEST_VERSION_MINOR 4
+#define DOCTEST_VERSION_PATCH 9
+
+// util we need here
+#define DOCTEST_TOSTR_IMPL(x) #x
+#define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
+
+#define DOCTEST_VERSION_STR                                                                        \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
+    DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
 
 #define DOCTEST_VERSION                                                                            \
     (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
@@ -59,6 +67,12 @@
 // =================================================================================================
 
 // ideas for the version stuff are taken from here: https://github.com/cxxstuff/cxx_detect
+
+#ifdef _MSC_VER
+#define DOCTEST_CPLUSPLUS _MSVC_LANG
+#else
+#define DOCTEST_CPLUSPLUS __cplusplus
+#endif
 
 #define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
 
@@ -137,85 +151,92 @@
 // == COMPILER WARNINGS ============================================================================
 // =================================================================================================
 
+// both the header and the implementation suppress all of these,
+// so it only makes sense to aggregrate them like so
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+                                                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                         \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                     \
+                                                                                                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
+    /* these 4 also disabled globally via cmake: */                                                \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                \
+    /* */                                                                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */ \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
+    /* static analysis */                                                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
+
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH
+
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-local-typedef")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")
-DOCTEST_GCC_SUPPRESS_WARNING("-Winline")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
-// static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtr...
-
-// 4548 - expression before comma has no effect; expected expression with side - effect
-// 4265 - class has virtual functions, but destructor is not virtual
-// 4986 - exception specification does not match previous declaration
-// 4350 - behavior change: 'member1' called instead of 'member2'
-// 4668 - 'x' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
-// 4365 - conversion from 'int' to 'unsigned long', signed/unsigned mismatch
-// 4774 - format string expected in argument 'x' is not a string literal
-// 4820 - padding in structs
-
-// only 4 should be disabled globally:
-// - 4514 # unreferenced inline function has been removed
-// - 4571 # SEH related
-// - 4710 # function not inlined
-// - 4711 # function 'x' selected for automatic inline expansion
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
     DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4265)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5105)
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -228,6 +249,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // GCC C++11 feature support table: https://gcc.gnu.org/projects/cxx-status.html
 // MSVC version table:
 // https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
+// MSVC++ 14.3 (17) _MSC_VER == 1930 (Visual Studio 2022)
 // MSVC++ 14.2 (16) _MSC_VER == 1920 (Visual Studio 2019)
 // MSVC++ 14.1 (15) _MSC_VER == 1910 (Visual Studio 2017)
 // MSVC++ 14.0      _MSC_VER == 1900 (Visual Studio 2015)
@@ -237,6 +259,10 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // MSVC++ 9.0       _MSC_VER == 1500 (Visual Studio 2008)
 // MSVC++ 8.0       _MSC_VER == 1400 (Visual Studio 2005)
 
+// Universal Windows Platform support
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_WINDOWS_SEH
+#endif // WINAPI_FAMILY
 #if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #define DOCTEST_CONFIG_WINDOWS_SEH
 #endif // MSVC
@@ -245,7 +271,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
 #if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) &&             \
-        !defined(__EMSCRIPTEN__)
+        !defined(__EMSCRIPTEN__) && !defined(__wasi__)
 #define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
@@ -253,7 +279,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
+        || defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
@@ -267,6 +294,10 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
 #define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+
+#ifdef __wasi__
+#define DOCTEST_CONFIG_NO_MULTITHREADING
+#endif
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
 #define DOCTEST_CONFIG_IMPLEMENT
@@ -295,21 +326,72 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_INTERFACE
 #endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
+// needed for extern template instantiations
+// see https://github.com/fmtlib/fmt/issues/2228
+#if DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL
+#define DOCTEST_INTERFACE_DEF DOCTEST_INTERFACE
+#else // DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL DOCTEST_INTERFACE
+#define DOCTEST_INTERFACE_DEF
+#endif // DOCTEST_MSVC
+
 #define DOCTEST_EMPTY
 
 #if DOCTEST_MSVC
 #define DOCTEST_NOINLINE __declspec(noinline)
 #define DOCTEST_UNUSED
 #define DOCTEST_ALIGNMENT(x)
-#else // MSVC
+#elif DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 5, 0)
+#define DOCTEST_NOINLINE
+#define DOCTEST_UNUSED
+#define DOCTEST_ALIGNMENT(x)
+#else
 #define DOCTEST_NOINLINE __attribute__((noinline))
 #define DOCTEST_UNUSED __attribute__((unused))
 #define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
-#endif // MSVC
+#endif
+
+#ifndef DOCTEST_NORETURN
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NORETURN
+#else // DOCTEST_MSVC
+#define DOCTEST_NORETURN [[noreturn]]
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NORETURN
+
+#ifndef DOCTEST_NOEXCEPT
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NOEXCEPT
+#else // DOCTEST_MSVC
+#define DOCTEST_NOEXCEPT noexcept
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NOEXCEPT
+
+#ifndef DOCTEST_CONSTEXPR
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_CONSTEXPR const
+#define DOCTEST_CONSTEXPR_FUNC inline
+#else // DOCTEST_MSVC
+#define DOCTEST_CONSTEXPR constexpr
+#define DOCTEST_CONSTEXPR_FUNC constexpr
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_CONSTEXPR
 
 // =================================================================================================
 // == FEATURE DETECTION END ========================================================================
 // =================================================================================================
+
+#define DOCTEST_DECLARE_INTERFACE(name)                                                            \
+    virtual ~name();                                                                               \
+    name() = default;                                                                              \
+    name(const name&) = delete;                                                                    \
+    name(name&&) = delete;                                                                         \
+    name& operator=(const name&) = delete;                                                         \
+    name& operator=(name&&) = delete;
+
+#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
+    name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -319,8 +401,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #else // __COUNTER__
 #define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
 #endif // __COUNTER__
-
-#define DOCTEST_TOSTR(x) #x
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x&
@@ -335,20 +415,40 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_PLATFORM_IPHONE
 #elif defined(_WIN32)
 #define DOCTEST_PLATFORM_WINDOWS
+#elif defined(__wasi__)
+#define DOCTEST_PLATFORM_WASI
 #else // DOCTEST_PLATFORM
 #define DOCTEST_PLATFORM_LINUX
 #endif // DOCTEST_PLATFORM
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var)                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                              \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-variable")                                            \
-    static int var DOCTEST_UNUSED // NOLINT(fuchsia-statically-constructed-objects,cert-err58-cpp)
-#define DOCTEST_GLOBAL_NO_WARNINGS_END() DOCTEST_CLANG_SUPPRESS_WARNING_POP
+namespace doctest { namespace detail {
+static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
+}}
+
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_BREAK_INTO_DEBUGGER
 // should probably take a look at https://github.com/scottt/debugbreak
-#ifdef DOCTEST_PLATFORM_MAC
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
+#ifdef DOCTEST_PLATFORM_LINUX
+#if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+// Break at the location of the failing check if possible
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#else
+#include <signal.h>
+#define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
+#endif
+#elif defined(DOCTEST_PLATFORM_MAC)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#elif defined(__ppc__) || defined(__ppc64__)
+// https://www.cocoawithlove.com/2008/03/break-into-debugger.html
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#else
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
+#endif
 #elif DOCTEST_MSVC
 #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
 #elif defined(__MINGW32__)
@@ -357,60 +457,72 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 #define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
 #else // linux
-#define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
+#define DOCTEST_BREAK_INTO_DEBUGGER() (static_cast<void>(0))
 #endif // linux
 #endif // DOCTEST_BREAK_INTO_DEBUGGER
 
 // this is kept here for backwards compatibility since the config option was changed
 #ifdef DOCTEST_CONFIG_USE_IOSFWD
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
 #define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
 #endif // DOCTEST_CONFIG_USE_IOSFWD
 
-#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
-#include <iosfwd>
-#include <cstddef>
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-#include <ostream>
-#endif // VS 2019
-#else // DOCTEST_CONFIG_USE_STD_HEADERS
-
+// for clang - always include ciso646 (which drags some std stuff) because
+// we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
+// which case we don't want to forward declare stuff from std - for reference:
+// https://github.com/doctest/doctest/issues/126
+// https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
-// to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
 #include <ciso646>
+#ifdef _LIBCPP_VERSION
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
+#define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
+#endif // _LIBCPP_VERSION
 #endif // clang
 
-#ifdef _LIBCPP_VERSION
-#define DOCTEST_STD_NAMESPACE_BEGIN _LIBCPP_BEGIN_NAMESPACE_STD
-#define DOCTEST_STD_NAMESPACE_END _LIBCPP_END_NAMESPACE_STD
-#else // _LIBCPP_VERSION
-#define DOCTEST_STD_NAMESPACE_BEGIN namespace std {
-#define DOCTEST_STD_NAMESPACE_END }
-#endif // _LIBCPP_VERSION
+#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+#ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstddef>
+#include <ostream>
+#include <istream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#else // DOCTEST_CONFIG_USE_STD_HEADERS
 
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-DOCTEST_STD_NAMESPACE_BEGIN // NOLINT (cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t;
+namespace std { // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream;
-typedef basic_ostream<char, char_traits<char>> ostream;
+class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
+template<class traits>
+// NOLINTNEXTLINE
+basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
+template <class charT, class traits>
+class basic_istream;
+typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
 class tuple;
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-template <class _Ty>
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+template <class Ty>
 class allocator;
-template <class _Elem, class _Traits, class _Alloc>
+template <class Elem, class Traits, class Alloc>
 class basic_string;
 using string = basic_string<char, char_traits<char>, allocator<char>>;
 #endif // VS 2019
-DOCTEST_STD_NAMESPACE_END
+} // namespace std
 
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -422,7 +534,13 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 namespace doctest {
 
+using std::size_t;
+
 DOCTEST_INTERFACE extern bool is_running_in_test;
+
+#ifndef DOCTEST_CONFIG_STRING_SIZE_TYPE
+#define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
+#endif
 
 // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
 // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
@@ -436,7 +554,6 @@ DOCTEST_INTERFACE extern bool is_running_in_test;
 // TODO:
 // - optimizations - like not deleting memory unnecessarily in operator= and etc.
 // - resize/reserve/clear
-// - substr
 // - replace
 // - back/front
 // - iterator stuff
@@ -446,62 +563,83 @@ DOCTEST_INTERFACE extern bool is_running_in_test;
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-    static const unsigned len  = 24;      //!OCLINT avoid private static members
-    static const unsigned last = len - 1; //!OCLINT avoid private static members
+public:
+  using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
 
-    struct view // len should be more than sizeof(view) - because of the final byte for flags
-    {
-        char*    ptr;
-        unsigned size;
-        unsigned capacity;
-    };
+private:
+  static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
+  static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
 
-    union
-    {
-        char buf[len];
-        view data;
-    };
+  struct view // len should be more than sizeof(view) - because of the final byte for flags
+  {
+    char*    ptr;
+    size_type size;
+    size_type capacity;
+  };
 
-    bool isOnStack() const { return (buf[last] & 128) == 0; }
-    void setOnHeap();
-    void setLast(unsigned in = last);
+  union
+  {
+    char buf[len]; // NOLINT(*-avoid-c-arrays)
+    view data;
+  };
 
-    void copy(const String& other);
+  char* allocate(size_type sz);
+
+  bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
+  void setOnHeap() noexcept;
+  void setLast(size_type in = last) noexcept;
+  void setSize(size_type sz) noexcept;
+
+  void copy(const String& other);
 
 public:
-    String();
-    ~String();
+  static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
 
-    // cppcheck-suppress noExplicitConstructor
-    String(const char* in);
-    String(const char* in, unsigned in_size);
+  String() noexcept;
+  ~String();
 
-    String(const String& other);
-    String& operator=(const String& other);
+  // cppcheck-suppress noExplicitConstructor
+  String(const char* in);
+  String(const char* in, size_type in_size);
 
-    String& operator+=(const String& other);
-    String  operator+(const String& other) const;
+  String(std::istream& in, size_type in_size);
 
-    String(String&& other);
-    String& operator=(String&& other);
+  String(const String& other);
+  String& operator=(const String& other);
 
-    char  operator[](unsigned i) const;
-    char& operator[](unsigned i);
+  String& operator+=(const String& other);
 
-    // the only functions I'm willing to leave in the interface - available for inlining
-    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-    char*       c_str() {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf);
-        return data.ptr;
+  String(String&& other) noexcept;
+  String& operator=(String&& other) noexcept;
+
+  char  operator[](size_type i) const;
+  char& operator[](size_type i);
+
+  // the only functions I'm willing to leave in the interface - available for inlining
+  const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
+  char*       c_str() {
+    if (isOnStack()) {
+      return reinterpret_cast<char*>(buf);
     }
+    return data.ptr;
+  }
 
-    unsigned size() const;
-    unsigned capacity() const;
+  size_type size() const;
+  size_type capacity() const;
 
-    int compare(const char* other, bool no_case = false) const;
-    int compare(const String& other, bool no_case = false) const;
+  String substr(size_type pos, size_type cnt = npos) &&;
+  String substr(size_type pos, size_type cnt = npos) const &;
+
+  size_type find(char ch, size_type pos = 0) const;
+  size_type rfind(char ch, size_type pos = npos) const;
+
+  int compare(const char* other, bool no_case = false) const;
+  int compare(const String& other, bool no_case = false) const;
+
+  friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
 };
+
+DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
@@ -510,120 +648,134 @@ DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
-DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+class DOCTEST_INTERFACE Contains {
+public:
+  explicit Contains(const String& string);
+
+  bool checkWith(const String& other) const;
+
+  String string;
+};
+
+DOCTEST_INTERFACE String toString(const Contains& in);
+
+DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator==(const Contains& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains& lhs, const String& rhs);
 
 namespace Color {
-    enum Enum
-    {
-        None = 0,
-        White,
-        Red,
-        Green,
-        Blue,
-        Cyan,
-        Yellow,
-        Grey,
+enum Enum
+{
+  None = 0,
+  White,
+  Red,
+  Green,
+  Blue,
+  Cyan,
+  Yellow,
+  Grey,
 
-        Bright = 0x10,
+  Bright = 0x10,
 
-        BrightRed   = Bright | Red,
-        BrightGreen = Bright | Green,
-        LightGrey   = Bright | Grey,
-        BrightWhite = Bright | White
-    };
+  BrightRed   = Bright | Red,
+  BrightGreen = Bright | Green,
+  LightGrey   = Bright | Grey,
+  BrightWhite = Bright | White
+};
 
-    DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
+DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
 } // namespace Color
 
 namespace assertType {
-    enum Enum
-    {
-        // macro traits
+enum Enum
+{
+  // macro traits
 
-        is_warn    = 1,
-        is_check   = 2 * is_warn,
-        is_require = 2 * is_check,
+  is_warn    = 1,
+  is_check   = 2 * is_warn,
+  is_require = 2 * is_check,
 
-        is_normal      = 2 * is_require,
-        is_throws      = 2 * is_normal,
-        is_throws_as   = 2 * is_throws,
-        is_throws_with = 2 * is_throws_as,
-        is_nothrow     = 2 * is_throws_with,
+  is_normal      = 2 * is_require,
+  is_throws      = 2 * is_normal,
+  is_throws_as   = 2 * is_throws,
+  is_throws_with = 2 * is_throws_as,
+  is_nothrow     = 2 * is_throws_with,
 
-        is_false = 2 * is_nothrow,
-        is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
+  is_false = 2 * is_nothrow,
+  is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
 
-        is_eq = 2 * is_unary,
-        is_ne = 2 * is_eq,
+  is_eq = 2 * is_unary,
+  is_ne = 2 * is_eq,
 
-        is_lt = 2 * is_ne,
-        is_gt = 2 * is_lt,
+  is_lt = 2 * is_ne,
+  is_gt = 2 * is_lt,
 
-        is_ge = 2 * is_gt,
-        is_le = 2 * is_ge,
+  is_ge = 2 * is_gt,
+  is_le = 2 * is_ge,
 
-        // macro types
+  // macro types
 
-        DT_WARN    = is_normal | is_warn,
-        DT_CHECK   = is_normal | is_check,
-        DT_REQUIRE = is_normal | is_require,
+  DT_WARN    = is_normal | is_warn,
+  DT_CHECK   = is_normal | is_check,
+  DT_REQUIRE = is_normal | is_require,
 
-        DT_WARN_FALSE    = is_normal | is_false | is_warn,
-        DT_CHECK_FALSE   = is_normal | is_false | is_check,
-        DT_REQUIRE_FALSE = is_normal | is_false | is_require,
+  DT_WARN_FALSE    = is_normal | is_false | is_warn,
+  DT_CHECK_FALSE   = is_normal | is_false | is_check,
+  DT_REQUIRE_FALSE = is_normal | is_false | is_require,
 
-        DT_WARN_THROWS    = is_throws | is_warn,
-        DT_CHECK_THROWS   = is_throws | is_check,
-        DT_REQUIRE_THROWS = is_throws | is_require,
+  DT_WARN_THROWS    = is_throws | is_warn,
+  DT_CHECK_THROWS   = is_throws | is_check,
+  DT_REQUIRE_THROWS = is_throws | is_require,
 
-        DT_WARN_THROWS_AS    = is_throws_as | is_warn,
-        DT_CHECK_THROWS_AS   = is_throws_as | is_check,
-        DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
+  DT_WARN_THROWS_AS    = is_throws_as | is_warn,
+  DT_CHECK_THROWS_AS   = is_throws_as | is_check,
+  DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-        DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
-        DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
-        DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
-        
-        DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
-        DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
-        DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
+  DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
+  DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
+  DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
 
-        DT_WARN_NOTHROW    = is_nothrow | is_warn,
-        DT_CHECK_NOTHROW   = is_nothrow | is_check,
-        DT_REQUIRE_NOTHROW = is_nothrow | is_require,
+  DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
+  DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
+  DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
 
-        DT_WARN_EQ    = is_normal | is_eq | is_warn,
-        DT_CHECK_EQ   = is_normal | is_eq | is_check,
-        DT_REQUIRE_EQ = is_normal | is_eq | is_require,
+  DT_WARN_NOTHROW    = is_nothrow | is_warn,
+  DT_CHECK_NOTHROW   = is_nothrow | is_check,
+  DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-        DT_WARN_NE    = is_normal | is_ne | is_warn,
-        DT_CHECK_NE   = is_normal | is_ne | is_check,
-        DT_REQUIRE_NE = is_normal | is_ne | is_require,
+  DT_WARN_EQ    = is_normal | is_eq | is_warn,
+  DT_CHECK_EQ   = is_normal | is_eq | is_check,
+  DT_REQUIRE_EQ = is_normal | is_eq | is_require,
 
-        DT_WARN_GT    = is_normal | is_gt | is_warn,
-        DT_CHECK_GT   = is_normal | is_gt | is_check,
-        DT_REQUIRE_GT = is_normal | is_gt | is_require,
+  DT_WARN_NE    = is_normal | is_ne | is_warn,
+  DT_CHECK_NE   = is_normal | is_ne | is_check,
+  DT_REQUIRE_NE = is_normal | is_ne | is_require,
 
-        DT_WARN_LT    = is_normal | is_lt | is_warn,
-        DT_CHECK_LT   = is_normal | is_lt | is_check,
-        DT_REQUIRE_LT = is_normal | is_lt | is_require,
+  DT_WARN_GT    = is_normal | is_gt | is_warn,
+  DT_CHECK_GT   = is_normal | is_gt | is_check,
+  DT_REQUIRE_GT = is_normal | is_gt | is_require,
 
-        DT_WARN_GE    = is_normal | is_ge | is_warn,
-        DT_CHECK_GE   = is_normal | is_ge | is_check,
-        DT_REQUIRE_GE = is_normal | is_ge | is_require,
+  DT_WARN_LT    = is_normal | is_lt | is_warn,
+  DT_CHECK_LT   = is_normal | is_lt | is_check,
+  DT_REQUIRE_LT = is_normal | is_lt | is_require,
 
-        DT_WARN_LE    = is_normal | is_le | is_warn,
-        DT_CHECK_LE   = is_normal | is_le | is_check,
-        DT_REQUIRE_LE = is_normal | is_le | is_require,
+  DT_WARN_GE    = is_normal | is_ge | is_warn,
+  DT_CHECK_GE   = is_normal | is_ge | is_check,
+  DT_REQUIRE_GE = is_normal | is_ge | is_require,
 
-        DT_WARN_UNARY    = is_normal | is_unary | is_warn,
-        DT_CHECK_UNARY   = is_normal | is_unary | is_check,
-        DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
+  DT_WARN_LE    = is_normal | is_le | is_warn,
+  DT_CHECK_LE   = is_normal | is_le | is_check,
+  DT_REQUIRE_LE = is_normal | is_le | is_require,
 
-        DT_WARN_UNARY_FALSE    = is_normal | is_false | is_unary | is_warn,
-        DT_CHECK_UNARY_FALSE   = is_normal | is_false | is_unary | is_check,
-        DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
-    };
+  DT_WARN_UNARY    = is_normal | is_unary | is_warn,
+  DT_CHECK_UNARY   = is_normal | is_unary | is_check,
+  DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
+
+  DT_WARN_UNARY_FALSE    = is_normal | is_false | is_unary | is_warn,
+  DT_CHECK_UNARY_FALSE   = is_normal | is_false | is_unary | is_check,
+  DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
+};
 } // namespace assertType
 
 DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
@@ -632,233 +784,316 @@ DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
 
 struct DOCTEST_INTERFACE TestCaseData
 {
-    const char* m_file;       // the file in which the test was registered
-    unsigned    m_line;       // the line where the test was registered
-    const char* m_name;       // name of the test case
-    const char* m_test_suite; // the test suite in which the test was added
-    const char* m_description;
-    bool        m_skip;
-    bool        m_may_fail;
-    bool        m_should_fail;
-    int         m_expected_failures;
-    double      m_timeout;
+  String      m_file;       // the file in which the test was registered (using String - see #350)
+  unsigned    m_line;       // the line where the test was registered
+  const char* m_name;       // name of the test case
+  const char* m_test_suite; // the test suite in which the test was added
+  const char* m_description;
+  bool        m_skip;
+  bool        m_no_breaks;
+  bool        m_no_output;
+  bool        m_may_fail;
+  bool        m_should_fail;
+  int         m_expected_failures;
+  double      m_timeout;
 };
 
 struct DOCTEST_INTERFACE AssertData
 {
-    // common - for all asserts
-    const TestCaseData* m_test_case;
-    assertType::Enum    m_at;
-    const char*         m_file;
-    int                 m_line;
-    const char*         m_expr;
-    bool                m_failed;
+  // common - for all asserts
+  const TestCaseData* m_test_case;
+  assertType::Enum    m_at;
+  const char*         m_file;
+  int                 m_line;
+  const char*         m_expr;
+  bool                m_failed;
 
-    // exception-related - for all asserts
-    bool   m_threw;
-    String m_exception;
+  // exception-related - for all asserts
+  bool   m_threw;
+  String m_exception;
 
-    // for normal asserts
-    String m_decomp;
+  // for normal asserts
+  String m_decomp;
 
-    // for specific exception-related asserts
-    bool        m_threw_as;
-    const char* m_exception_type;
-    const char* m_exception_string;
+  // for specific exception-related asserts
+  bool           m_threw_as;
+  const char*    m_exception_type;
+
+  class DOCTEST_INTERFACE StringContains {
+  private:
+    Contains content;
+    bool isContains;
+
+  public:
+    StringContains(const String& str) : content(str), isContains(false) { }
+    StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
+
+    bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
+
+    operator const String&() const { return content.string; }
+
+    const char* c_str() const { return content.string.c_str(); }
+  } m_exception_string;
+
+  AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+             const char* exception_type, const StringContains& exception_string);
 };
 
 struct DOCTEST_INTERFACE MessageData
 {
-    String           m_string;
-    const char*      m_file;
-    int              m_line;
-    assertType::Enum m_severity;
+  String           m_string;
+  const char*      m_file;
+  int              m_line;
+  assertType::Enum m_severity;
 };
 
 struct DOCTEST_INTERFACE SubcaseSignature
 {
-    const char* m_name;
-    const char* m_file;
-    int         m_line;
+  String      m_name;
+  const char* m_file;
+  int         m_line;
 
-    bool operator<(const SubcaseSignature& other) const;
+  bool operator==(const SubcaseSignature& other) const;
+  bool operator<(const SubcaseSignature& other) const;
 };
 
 struct DOCTEST_INTERFACE IContextScope
 {
-    IContextScope();
-    virtual ~IContextScope();
-    virtual void stringify(std::ostream*) const = 0;
-};
-
-struct ContextOptions //!OCLINT too many fields
-{
-    std::ostream* cout;        // stdout stream - std::cout by default
-    std::ostream* cerr;        // stderr stream - std::cerr by default
-    String        binary_name; // the test binary name
-
-    // == parameters from the command line
-    String   out;       // output filename
-    String   order_by;  // how tests should be ordered
-    unsigned rand_seed; // the seed for rand ordering
-
-    unsigned first; // the first (matching) test to be executed
-    unsigned last;  // the last (matching) test to be executed
-
-    int abort_after;           // stop tests after this many failed assertions
-    int subcase_filter_levels; // apply the subcase filters for the first N levels
-
-    bool success;              // include successful assertions in output
-    bool case_sensitive;       // if filtering should be case sensitive
-    bool exit;                 // if the program should be exited after the tests are ran/whatever
-    bool duration;             // print the time duration of each test case
-    bool no_throw;             // to skip exceptions-related assertion macros
-    bool no_exitcode;          // if the framework should return 0 as the exitcode
-    bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-    bool no_version;           // to not print the version of the framework
-    bool no_colors;            // if output to the console should be colorized
-    bool force_colors;         // forces the use of colors even when a tty cannot be detected
-    bool no_breaks;            // to not break into the debugger
-    bool no_skip;              // don't skip test cases which are marked to be skipped
-    bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-    bool no_path_in_filenames; // if the path to files should be removed from the output
-    bool no_line_numbers;      // if source code line numbers should be omitted from the output
-    bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
-
-    bool help;             // to print the help
-    bool version;          // to print the version
-    bool count;            // if only the count of matching tests is to be retrieved
-    bool list_test_cases;  // to list all tests matching the filters
-    bool list_test_suites; // to list all suites matching the filters
-    bool list_reporters;   // lists all registered reporters
+  DOCTEST_DECLARE_INTERFACE(IContextScope)
+  virtual void stringify(std::ostream*) const = 0;
 };
 
 namespace detail {
-#if defined(DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || defined(DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS)
-    template <bool CONDITION, typename TYPE = void>
-    struct enable_if
-    {};
+struct DOCTEST_INTERFACE TestCase;
+} // namespace detail
 
-    template <typename TYPE>
-    struct enable_if<true, TYPE>
-    { typedef TYPE type; };
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+struct ContextOptions //!OCLINT too many fields
+{
+  std::ostream* cout = nullptr; // stdout stream
+  String        binary_name;    // the test binary name
 
-    // clang-format off
-    template<class T> struct remove_reference      { typedef T type; };
-    template<class T> struct remove_reference<T&>  { typedef T type; };
-    template<class T> struct remove_reference<T&&> { typedef T type; };
+  const detail::TestCase* currentTest = nullptr;
 
-    template<class T> struct remove_const          { typedef T type; };
-    template<class T> struct remove_const<const T> { typedef T type; };
-    // clang-format on
+  // == parameters from the command line
+  String   out;       // output filename
+  String   order_by;  // how tests should be ordered
+  unsigned rand_seed; // the seed for rand ordering
 
-    template <typename T>
-    struct deferred_false
-    // cppcheck-suppress unusedStructMember
-    { static const bool value = false; };
+  unsigned first; // the first (matching) test to be executed
+  unsigned last;  // the last (matching) test to be executed
 
-    namespace has_insertion_operator_impl {
-        typedef char no;
-        typedef char yes[2];
+  int abort_after;           // stop tests after this many failed assertions
+  int subcase_filter_levels; // apply the subcase filters for the first N levels
 
-        struct any_t
-        {
-            template <typename T>
-            // cppcheck-suppress noExplicitConstructor
-            any_t(const DOCTEST_REF_WRAP(T));
-        };
+  bool success;              // include successful assertions in output
+  bool case_sensitive;       // if filtering should be case sensitive
+  bool exit;                 // if the program should be exited after the tests are ran/whatever
+  bool duration;             // print the time duration of each test case
+  bool minimal;              // minimal console output (only test failures)
+  bool quiet;                // no console output
+  bool no_throw;             // to skip exceptions-related assertion macros
+  bool no_exitcode;          // if the framework should return 0 as the exitcode
+  bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
+  bool no_intro;             // to not print the intro of the framework
+  bool no_version;           // to not print the version of the framework
+  bool no_colors;            // if output to the console should be colorized
+  bool force_colors;         // forces the use of colors even when a tty cannot be detected
+  bool no_breaks;            // to not break into the debugger
+  bool no_skip;              // don't skip test cases which are marked to be skipped
+  bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
+  bool no_path_in_filenames; // if the path to files should be removed from the output
+  bool no_line_numbers;      // if source code line numbers should be omitted from the output
+  bool no_debug_output;      // no output in the debug console when a debugger is attached
+  bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+  bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
-        yes& testStreamable(std::ostream&);
-        no   testStreamable(no);
+  bool help;             // to print the help
+  bool version;          // to print the version
+  bool count;            // if only the count of matching tests is to be retrieved
+  bool list_test_cases;  // to list all tests matching the filters
+  bool list_test_suites; // to list all suites matching the filters
+  bool list_reporters;   // lists all registered reporters
+};
 
-        no operator<<(const std::ostream&, const any_t&);
+namespace detail {
+namespace types {
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+using namespace std;
+#else
+template <bool COND, typename T = void>
+struct enable_if { };
 
-        template <typename T>
-        struct has_insertion_operator
-        {
-            static std::ostream& s;
-            static const DOCTEST_REF_WRAP(T) t;
-            static const bool value = sizeof(decltype(testStreamable(s << t))) == sizeof(yes);
-        };
-    } // namespace has_insertion_operator_impl
+template <typename T>
+struct enable_if<true, T> { using type = T; };
 
-    template <typename T>
-    struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-    {};
+struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
+struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
 
-    DOCTEST_INTERFACE void my_memcpy(void* dest, const void* src, unsigned num);
+template <typename T> struct remove_reference { using type = T; };
+template <typename T> struct remove_reference<T&> { using type = T; };
+template <typename T> struct remove_reference<T&&> { using type = T; };
 
-    DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
-    DOCTEST_INTERFACE String getTlsOssResult();
+template <typename T> struct is_rvalue_reference : false_type { };
+template <typename T> struct is_rvalue_reference<T&&> : true_type { };
 
-    template <bool C>
-    struct StringMakerBase
-    {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
-            return "{?}";
-        }
-    };
+template<typename T> struct remove_const { using type = T; };
+template <typename T> struct remove_const<const T> { using type = T; };
 
-    template <>
-    struct StringMakerBase<true>
-    {
-        template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
-            *getTlsOss() << in;
-            return getTlsOssResult();
-        }
-    };
+// Compiler intrinsics
+template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
+template <typename T> struct underlying_type { using type = __underlying_type(T); };
 
-    DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
+template <typename T> struct is_pointer : false_type { };
+template <typename T> struct is_pointer<T*> : true_type { };
 
-    template <typename T>
-    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object) {
-        return rawMemoryToString(&object, sizeof(object));
-    }
+template <typename T> struct is_array : false_type { };
+// NOLINTNEXTLINE(*-avoid-c-arrays)
+template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+#endif
+}
 
-    template <typename T>
-    const char* type_to_string() {
-        return "<>";
-    }
+    // <utility>
+template <typename T>
+T&& declval();
+
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
+  return static_cast<T&&>(t);
+}
+
+template <typename T>
+struct deferred_false : types::false_type { };
+
+// MSVS 2015 :(
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+template <typename T, typename = void>
+struct has_global_insertion_operator : types::false_type { };
+
+template <typename T>
+struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+template <typename T, typename = void>
+struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+
+template <typename T, bool global>
+struct insert_hack;
+
+template <typename T>
+struct insert_hack<T, true> {
+  static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
+};
+
+template <typename T>
+struct insert_hack<T, false> {
+  static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
+};
+
+template <typename T>
+using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
+#else
+template <typename T, typename = void>
+struct has_insertion_operator : types::false_type { };
+#endif
+
+template <typename T>
+struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+DOCTEST_INTERFACE std::ostream* tlssPush();
+DOCTEST_INTERFACE String tlssPop();
+
+template <bool C>
+struct StringMakerBase {
+  template <typename T>
+  static String convert(const DOCTEST_REF_WRAP(T)) {
+#ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
+    static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+#endif
+    return "{?}";
+  }
+};
+
+template <typename T>
+struct filldata;
+
+template <typename T>
+void filloss(std::ostream* stream, const T& in) {
+  filldata<T>::fill(stream, in);
+}
+
+template <typename T, size_t N>
+void filloss(std::ostream* stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
+  // T[N], T(&)[N], T(&&)[N] have same behaviour.
+  // Hence remove reference.
+  filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
+}
+
+template <typename T>
+String toStream(const T& in) {
+  std::ostream* stream = tlssPush();
+  filloss(stream, in);
+  return tlssPop();
+}
+
+template <>
+struct StringMakerBase<true> {
+  template <typename T>
+  static String convert(const DOCTEST_REF_WRAP(T) in) {
+    return toStream(in);
+  }
+};
 } // namespace detail
 
 template <typename T>
-struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value>
+struct StringMaker : public detail::StringMakerBase<
+                         detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
 {};
 
-template <typename T>
-struct StringMaker<T*>
-{
-    template <typename U>
-    static String convert(U* p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
-};
-
-template <typename R, typename C>
-struct StringMaker<R C::*>
-{
-    static String convert(R C::*p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
-};
+#ifndef DOCTEST_STRINGIFY
+#ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
+#define DOCTEST_STRINGIFY(...) toString(toString(__VA_ARGS__))
+#else
+#define DOCTEST_STRINGIFY(...) toString(__VA_ARGS__)
+#endif
+#endif
 
 template <typename T>
+String toString() {
+#if DOCTEST_MSVC >= 0 && DOCTEST_CLANG == 0 && DOCTEST_GCC == 0
+  String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+  String::size_type beginPos = ret.find('<');
+  return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+  String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+  String::size_type begin = ret.find('=') + 2;
+  return ret.substr(begin, ret.size() - begin - 1);
+#endif
+}
+
+template <typename T, typename detail::types::enable_if<!detail::types::is_enum<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
-    return StringMaker<T>::convert(value);
+  return StringMaker<T>::convert(value);
 }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE String toString(char* in);
 DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string& in);
+#endif // VS 2019
+
+DOCTEST_INTERFACE String toString(String in);
+
+DOCTEST_INTERFACE String toString(std::nullptr_t);
+
 DOCTEST_INTERFACE String toString(bool in);
+
 DOCTEST_INTERFACE String toString(float in);
 DOCTEST_INTERFACE String toString(double in);
 DOCTEST_INTERFACE String toString(double long in);
@@ -866,60 +1101,111 @@ DOCTEST_INTERFACE String toString(double long in);
 DOCTEST_INTERFACE String toString(char in);
 DOCTEST_INTERFACE String toString(char signed in);
 DOCTEST_INTERFACE String toString(char unsigned in);
-DOCTEST_INTERFACE String toString(int short in);
-DOCTEST_INTERFACE String toString(int short unsigned in);
-DOCTEST_INTERFACE String toString(int in);
-DOCTEST_INTERFACE String toString(int unsigned in);
-DOCTEST_INTERFACE String toString(int long in);
-DOCTEST_INTERFACE String toString(int long unsigned in);
-DOCTEST_INTERFACE String toString(int long long in);
-DOCTEST_INTERFACE String toString(int long long unsigned in);
-DOCTEST_INTERFACE String toString(std::nullptr_t in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-DOCTEST_INTERFACE String toString(const std::string& in);
-#endif // VS 2019
+template <typename T, typename detail::types::enable_if<detail::types::is_enum<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+  using UT = typename detail::types::underlying_type<T>::type;
+  return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
-class DOCTEST_INTERFACE Approx
+namespace detail {
+template <typename T>
+struct filldata
 {
-public:
-    explicit Approx(double value);
+  static void fill(std::ostream* stream, const T& in) {
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+    insert_hack_t<T>::insert(*stream, in);
+#else
+    operator<<(*stream, in);
+#endif
+  }
+};
 
-    Approx operator()(double value) const;
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <typename T, size_t N>
+struct filldata<T[N]> {
+  static void fill(std::ostream* stream, const T(&in)[N]) {
+    *stream << "[";
+    for (size_t i = 0; i < N; i++) {
+      if (i != 0) { *stream << ", "; }
+      *stream << (DOCTEST_STRINGIFY(in[i]));
+    }
+    *stream << "]";
+  }
+};
+// NOLINTEND(*-avoid-c-arrays)
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+// Specialized since we don't want the terminating null byte!
+// NOLINTBEGIN(*-avoid-c-arrays)
+template <size_t N>
+struct filldata<const char[N]> {
+  static void fill(std::ostream* stream, const char (&in)[N]) {
+    *stream << String(in, in[N - 1] ? N : N - 1);
+  } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+};
+// NOLINTEND(*-avoid-c-arrays)
+
+template <>
+struct filldata<const void*> {
+  static void fill(std::ostream* stream, const void* in);
+};
+
+template <typename T>
+struct filldata<T*> {
+  static void fill(std::ostream* stream, const T* in) {
+    filldata<const void*>::fill(stream, in);
+  }
+};
+}
+
+struct DOCTEST_INTERFACE Approx
+{
+  Approx(double value);
+
+  Approx operator()(double value) const;
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
-        *this = Approx(static_cast<double>(value));
-    }
+  template <typename T>
+  explicit Approx(const T& value,
+                  typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
+                      static_cast<T*>(nullptr)) {
+    *this = static_cast<double>(value);
+  }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& epsilon(double newEpsilon);
+  Approx& epsilon(double newEpsilon);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
-            const T& newEpsilon) {
-        m_epsilon = static_cast<double>(newEpsilon);
-        return *this;
-    }
+  template <typename T>
+  typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
+      const T& newEpsilon) {
+    m_epsilon = static_cast<double>(newEpsilon);
+    return *this;
+  }
 #endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    Approx& scale(double newScale);
+  Approx& scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-    template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
-            const T& newScale) {
-        m_scale = static_cast<double>(newScale);
-        return *this;
-    }
+  template <typename T>
+  typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
+      const T& newScale) {
+    m_scale = static_cast<double>(newScale);
+    return *this;
+  }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    // clang-format off
+  // clang-format off
     DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx & rhs);
     DOCTEST_INTERFACE friend bool operator==(const Approx & lhs, double rhs);
     DOCTEST_INTERFACE friend bool operator!=(double lhs, const Approx & rhs);
@@ -933,88 +1219,119 @@ public:
     DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx & rhs);
     DOCTEST_INTERFACE friend bool operator> (const Approx & lhs, double rhs);
 
-    DOCTEST_INTERFACE friend String toString(const Approx& in);
-
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #define DOCTEST_APPROX_PREFIX \
-    template <typename T> friend typename detail::enable_if<std::is_constructible<double, T>::value, bool>::type
+    template <typename T> friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
 
-    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(double(lhs), rhs); }
+    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(static_cast<double>(lhs), rhs); }
     DOCTEST_APPROX_PREFIX operator==(const Approx& lhs, const T& rhs) { return operator==(rhs, lhs); }
     DOCTEST_APPROX_PREFIX operator!=(const T& lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
     DOCTEST_APPROX_PREFIX operator!=(const Approx& lhs, const T& rhs) { return !operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return double(lhs) < rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < double(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return double(lhs) > rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > double(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return double(lhs) < rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < double(rhs) && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return double(lhs) > rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > double(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-    // clang-format on
+  // clang-format on
 
-private:
-    double m_epsilon;
-    double m_scale;
-    double m_value;
+  double m_epsilon;
+  double m_scale;
+  double m_value;
 };
 
 DOCTEST_INTERFACE String toString(const Approx& in);
 
 DOCTEST_INTERFACE const ContextOptions* getContextOptions();
 
-#if !defined(DOCTEST_CONFIG_DISABLE)
+template <typename F>
+struct DOCTEST_INTERFACE_DECL IsNaN
+{
+  F value; bool flipped;
+  IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
+  IsNaN<F> operator!() const { return { value, !flipped }; }
+  operator bool() const;
+};
+#ifndef __MINGW32__
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<float>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<double>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<long double>;
+#endif
+DOCTEST_INTERFACE String toString(IsNaN<float> in);
+DOCTEST_INTERFACE String toString(IsNaN<double> in);
+DOCTEST_INTERFACE String toString(IsNaN<double long> in);
+
+#ifndef DOCTEST_CONFIG_DISABLE
 
 namespace detail {
-    // clang-format off
+// clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    template<class T>               struct decay_array       { typedef T type; };
-    template<class T, unsigned N>   struct decay_array<T[N]> { typedef T* type; };
-    template<class T>               struct decay_array<T[]>  { typedef T* type; };
+    template<class T>               struct decay_array       { using type = T; };
+    template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
+    template<class T>               struct decay_array<T[]>  { using type = T*; };
 
-    template<class T>   struct not_char_pointer              { enum { value = 1 }; };
-    template<>          struct not_char_pointer<char*>       { enum { value = 0 }; };
-    template<>          struct not_char_pointer<const char*> { enum { value = 0 }; };
+    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR value = 1; };
+    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR value = 0; };
+    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR value = 0; };
 
     template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
+// clang-format on
 
-    struct DOCTEST_INTERFACE TestFailureException
-    {
-    };
+struct DOCTEST_INTERFACE TestFailureException
+{
+};
 
-    DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
+DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    [[noreturn]]
+DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    DOCTEST_INTERFACE void throwException();
+DOCTEST_INTERFACE void throwException();
 
-    struct DOCTEST_INTERFACE Subcase
-    {
-        SubcaseSignature m_signature;
-        bool             m_entered = false;
+struct DOCTEST_INTERFACE Subcase
+{
+  SubcaseSignature m_signature;
+  bool             m_entered = false;
 
-        Subcase(const char* name, const char* file, int line);
-        ~Subcase();
+  Subcase(const String& name, const char* file, int line);
+  Subcase(const Subcase&) = delete;
+  Subcase(Subcase&&) = delete;
+  Subcase& operator=(const Subcase&) = delete;
+  Subcase& operator=(Subcase&&) = delete;
+  ~Subcase();
 
-        operator bool() const;
-    };
+  operator bool() const;
 
-    template <typename L, typename R>
-    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
-                               const DOCTEST_REF_WRAP(R) rhs) {
-        return toString(lhs) + op + toString(rhs);
-    }
+private:
+  bool checkFilters();
+};
+
+template <typename L, typename R>
+String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
+                           const DOCTEST_REF_WRAP(R) rhs) {
+  return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
+}
+
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
+#endif
+
+// This will check if there is any way it could find a operator like member or friend and uses it.
+// If not it doesn't find the operator or if the operator at global scope is defined after
+// this template, the template won't be instantiated due to SFINAE. Once the template is not
+// instantiated it can look for global operator using normal conversions.
+#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
-        bool res = op_macro(lhs, rhs);                                                             \
+    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
+    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
         if(!res || doctest::getContextOptions()->success)                                          \
@@ -1022,9 +1339,9 @@ namespace detail {
         return Result(res);                                                                        \
     }
 
-    // more checks could be added - like in Catch:
-    // https://github.com/catchorg/Catch2/pull/1480/files
-    // https://github.com/catchorg/Catch2/pull/1481/files
+// more checks could be added - like in Catch:
+// https://github.com/catchorg/Catch2/pull/1480/files
+// https://github.com/catchorg/Catch2/pull/1481/files
 #define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                          \
     template <typename R>                                                                          \
     rt& operator op(const R&) {                                                                    \
@@ -1033,68 +1350,69 @@ namespace detail {
         return *this;                                                                              \
     }
 
-    struct DOCTEST_INTERFACE Result
-    {
-        bool   m_passed;
-        String m_decomp;
+struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
+{
+  bool   m_passed;
+  String m_decomp;
 
-        Result(bool passed, const String& decomposition = String());
+  Result() = default; // TODO: Why do we need this? (To remove NOLINT)
+  Result(bool passed, const String& decomposition = String());
 
-        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
-        DOCTEST_FORBIT_EXPRESSION(Result, &)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^)
-        DOCTEST_FORBIT_EXPRESSION(Result, |)
-        DOCTEST_FORBIT_EXPRESSION(Result, &&)
-        DOCTEST_FORBIT_EXPRESSION(Result, ||)
-        DOCTEST_FORBIT_EXPRESSION(Result, ==)
-        DOCTEST_FORBIT_EXPRESSION(Result, !=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <)
-        DOCTEST_FORBIT_EXPRESSION(Result, >)
-        DOCTEST_FORBIT_EXPRESSION(Result, <=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >=)
-        DOCTEST_FORBIT_EXPRESSION(Result, =)
-        DOCTEST_FORBIT_EXPRESSION(Result, +=)
-        DOCTEST_FORBIT_EXPRESSION(Result, -=)
-        DOCTEST_FORBIT_EXPRESSION(Result, *=)
-        DOCTEST_FORBIT_EXPRESSION(Result, /=)
-        DOCTEST_FORBIT_EXPRESSION(Result, %=)
-        DOCTEST_FORBIT_EXPRESSION(Result, <<=)
-        DOCTEST_FORBIT_EXPRESSION(Result, >>=)
-        DOCTEST_FORBIT_EXPRESSION(Result, &=)
-        DOCTEST_FORBIT_EXPRESSION(Result, ^=)
-        DOCTEST_FORBIT_EXPRESSION(Result, |=)
-    };
+  // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+  DOCTEST_FORBIT_EXPRESSION(Result, &)
+  DOCTEST_FORBIT_EXPRESSION(Result, ^)
+  DOCTEST_FORBIT_EXPRESSION(Result, |)
+  DOCTEST_FORBIT_EXPRESSION(Result, &&)
+  DOCTEST_FORBIT_EXPRESSION(Result, ||)
+  DOCTEST_FORBIT_EXPRESSION(Result, ==)
+  DOCTEST_FORBIT_EXPRESSION(Result, !=)
+  DOCTEST_FORBIT_EXPRESSION(Result, <)
+  DOCTEST_FORBIT_EXPRESSION(Result, >)
+  DOCTEST_FORBIT_EXPRESSION(Result, <=)
+  DOCTEST_FORBIT_EXPRESSION(Result, >=)
+  DOCTEST_FORBIT_EXPRESSION(Result, =)
+  DOCTEST_FORBIT_EXPRESSION(Result, +=)
+  DOCTEST_FORBIT_EXPRESSION(Result, -=)
+  DOCTEST_FORBIT_EXPRESSION(Result, *=)
+  DOCTEST_FORBIT_EXPRESSION(Result, /=)
+  DOCTEST_FORBIT_EXPRESSION(Result, %=)
+  DOCTEST_FORBIT_EXPRESSION(Result, <<=)
+  DOCTEST_FORBIT_EXPRESSION(Result, >>=)
+  DOCTEST_FORBIT_EXPRESSION(Result, &=)
+  DOCTEST_FORBIT_EXPRESSION(Result, ^=)
+  DOCTEST_FORBIT_EXPRESSION(Result, |=)
+};
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-compare")
+//DOCTEST_CLANG_SUPPRESS_WARNING("-Wdouble-promotion")
+//DOCTEST_CLANG_SUPPRESS_WARNING("-Wconversion")
+//DOCTEST_CLANG_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-    DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-    //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
+DOCTEST_GCC_SUPPRESS_WARNING_PUSH
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
+DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-compare")
+//DOCTEST_GCC_SUPPRESS_WARNING("-Wdouble-promotion")
+//DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
+//DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    // http://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
-    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
-    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
+DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
+// https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
+DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+                                    //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    // clang-format off
+// clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_COMPARISON_RETURN_TYPE bool
 #else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#define DOCTEST_COMPARISON_RETURN_TYPE typename enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
+#define DOCTEST_COMPARISON_RETURN_TYPE typename types::enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
     inline bool eq(const char* lhs, const char* rhs) { return String(lhs) == String(rhs); }
     inline bool ne(const char* lhs, const char* rhs) { return String(lhs) != String(rhs); }
     inline bool lt(const char* lhs, const char* rhs) { return String(lhs) <  String(rhs); }
@@ -1102,7 +1420,7 @@ namespace detail {
     inline bool le(const char* lhs, const char* rhs) { return String(lhs) <= String(rhs); }
     inline bool ge(const char* lhs, const char* rhs) { return String(lhs) >= String(rhs); }
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    // clang-format on
+// clang-format on
 
 #define DOCTEST_RELATIONAL_OP(name, op)                                                            \
     template <typename L, typename R>                                                              \
@@ -1111,12 +1429,12 @@ namespace detail {
         return lhs op rhs;                                                                         \
     }
 
-    DOCTEST_RELATIONAL_OP(eq, ==)
-    DOCTEST_RELATIONAL_OP(ne, !=)
-    DOCTEST_RELATIONAL_OP(lt, <)
-    DOCTEST_RELATIONAL_OP(gt, >)
-    DOCTEST_RELATIONAL_OP(le, <=)
-    DOCTEST_RELATIONAL_OP(ge, >=)
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
 
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_CMP_EQ(l, r) l == r
@@ -1134,211 +1452,244 @@ namespace detail {
 #define DOCTEST_CMP_LE(l, r) le(l, r)
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
-    template <typename L>
-    // cppcheck-suppress copyCtorAndEqOperator
-    struct Expression_lhs
-    {
-        L                lhs;
-        assertType::Enum m_at;
+template <typename L>
+// cppcheck-suppress copyCtorAndEqOperator
+struct Expression_lhs
+{
+  L                lhs;
+  assertType::Enum m_at;
 
-        explicit Expression_lhs(L in, assertType::Enum at)
-                : lhs(in)
-                , m_at(at) {}
+  explicit Expression_lhs(L&& in, assertType::Enum at)
+      : lhs(static_cast<L&&>(in))
+        , m_at(at) {}
 
-        DOCTEST_NOINLINE operator Result() {
-            bool res = !!lhs;
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
-                res = !res;
+  DOCTEST_NOINLINE operator Result() {
+    // this is needed only for MSVC 2015
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+    bool res = static_cast<bool>(lhs);
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+    if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+      res = !res;
+    }
 
-            if(!res || getContextOptions()->success)
-                return Result(res, toString(lhs));
-            return Result(res);
-        }
+    if(!res || getContextOptions()->success) {
+      return { res, (DOCTEST_STRINGIFY(lhs)) };
+    }
+    return { res };
+  }
 
-        // clang-format off
+  /* This is required for user-defined conversions from Expression_lhs to L */
+  operator L() const { return lhs; }
+
+  // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(!=, " != ", DOCTEST_CMP_NE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>,  " >  ", DOCTEST_CMP_GT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<,  " <  ", DOCTEST_CMP_LT) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(>=, " >= ", DOCTEST_CMP_GE) //!OCLINT bitwise operator in conditional
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
-        // clang-format on
+  // clang-format on
 
-        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
-        // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
-        // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
-        DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
-    };
+  // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &&)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ||)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, =)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, +=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, -=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, *=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, /=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, %=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^=)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |=)
+  // these 2 are unfortunate because they should be allowed - they have higher precedence over the comparisons, but the
+  // ExpressionDecomposer class uses the left shift operator to capture the left operand of the binary expression...
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, <<)
+  DOCTEST_FORBIT_EXPRESSION(Expression_lhs, >>)
+};
 
 #ifndef DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
-    struct DOCTEST_INTERFACE ExpressionDecomposer
-    {
-        assertType::Enum m_at;
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#endif
 
-        ExpressionDecomposer(assertType::Enum at);
+struct DOCTEST_INTERFACE ExpressionDecomposer
+{
+  assertType::Enum m_at;
 
-        // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
-        // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
-        // https://github.com/catchorg/Catch2/issues/870
-        // https://github.com/catchorg/Catch2/issues/565
-        template <typename L>
-        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
-            return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_at);
-        }
-    };
+  ExpressionDecomposer(assertType::Enum at);
 
-    struct DOCTEST_INTERFACE TestSuite
-    {
-        const char* m_test_suite;
-        const char* m_description;
-        bool        m_skip;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
+  // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
+  // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
+  // https://github.com/catchorg/Catch2/issues/870
+  // https://github.com/catchorg/Catch2/issues/565
+  template <typename L>
+  Expression_lhs<L> operator<<(L&& operand) {
+    return Expression_lhs<L>(static_cast<L&&>(operand), m_at);
+  }
 
-        TestSuite& operator*(const char* in);
+  template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
+  Expression_lhs<const L&> operator<<(const L &operand) {
+    return Expression_lhs<const L&>(operand, m_at);
+  }
+};
 
-        template <typename T>
-        TestSuite& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
-    };
+struct DOCTEST_INTERFACE TestSuite
+{
+  const char* m_test_suite = nullptr;
+  const char* m_description = nullptr;
+  bool        m_skip = false;
+  bool        m_no_breaks = false;
+  bool        m_no_output = false;
+  bool        m_may_fail = false;
+  bool        m_should_fail = false;
+  int         m_expected_failures = 0;
+  double      m_timeout = 0;
 
-    typedef void (*funcType)();
+  TestSuite& operator*(const char* in);
 
-    struct DOCTEST_INTERFACE TestCase : public TestCaseData
-    {
-        funcType m_test; // a function pointer to the test case
+  template <typename T>
+  TestSuite& operator*(const T& in) {
+    in.fill(*this);
+    return *this;
+  }
+};
 
-        const char* m_type; // for templated test cases - gets appended to the real name
-        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
-        String m_full_name; // contains the name (only for templated test cases!) + the template type
+using funcType = void (*)();
 
-        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                 const char* type = "", int template_id = -1);
+struct DOCTEST_INTERFACE TestCase : public TestCaseData
+{
+  funcType m_test; // a function pointer to the test case
 
-        TestCase(const TestCase& other);
+  String m_type; // for templated test cases - gets appended to the real name
+  int m_template_id; // an ID used to distinguish between the different versions of a templated test case
+  String m_full_name; // contains the name (only for templated test cases!) + the template type
 
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-        TestCase& operator=(const TestCase& other);
-        DOCTEST_MSVC_SUPPRESS_WARNING_POP
+  TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+           const String& type = String(), int template_id = -1);
 
-        TestCase& operator*(const char* in);
+  TestCase(const TestCase& other);
+  TestCase(TestCase&&) = delete;
 
-        template <typename T>
-        TestCase& operator*(const T& in) {
-            in.fill(*this);
-            return *this;
-        }
+  DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+  TestCase& operator=(const TestCase& other);
+  DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        bool operator<(const TestCase& other) const;
-    };
+  TestCase& operator=(TestCase&&) = delete;
 
-    // forward declarations of functions used by the macros
-    DOCTEST_INTERFACE int  regTest(const TestCase& tc);
-    DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
-    DOCTEST_INTERFACE bool isDebuggerActive();
+  TestCase& operator*(const char* in);
 
-    template<typename T>
-    int instantiationHelper(const T&) { return 0; }
+  template <typename T>
+  TestCase& operator*(const T& in) {
+    in.fill(*this);
+    return *this;
+  }
 
-    namespace binaryAssertComparison {
-        enum Enum
-        {
-            eq = 0,
-            ne,
-            gt,
-            lt,
-            ge,
-            le
-        };
-    } // namespace binaryAssertComparison
+  bool operator<(const TestCase& other) const;
 
-    // clang-format off
+  ~TestCase() = default;
+};
+
+// forward declarations of functions used by the macros
+DOCTEST_INTERFACE int  regTest(const TestCase& tc);
+DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
+DOCTEST_INTERFACE bool isDebuggerActive();
+
+template<typename T>
+int instantiationHelper(const T&) { return 0; }
+
+namespace binaryAssertComparison {
+enum Enum
+{
+  eq = 0,
+  ne,
+  gt,
+  lt,
+  ge,
+  le
+};
+} // namespace binaryAssertComparison
+
+// clang-format off
     template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
 
 #define DOCTEST_BINARY_RELATIONAL_OP(n, op) \
     template <class L, class R> struct RelationalComparator<n, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return op(lhs, rhs); } };
-    // clang-format on
+// clang-format on
 
-    DOCTEST_BINARY_RELATIONAL_OP(0, eq)
-    DOCTEST_BINARY_RELATIONAL_OP(1, ne)
-    DOCTEST_BINARY_RELATIONAL_OP(2, gt)
-    DOCTEST_BINARY_RELATIONAL_OP(3, lt)
-    DOCTEST_BINARY_RELATIONAL_OP(4, ge)
-    DOCTEST_BINARY_RELATIONAL_OP(5, le)
+DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
+DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
+DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
+DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
+DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
+DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
-    struct DOCTEST_INTERFACE ResultBuilder : public AssertData
-    {
-        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type = "", const char* exception_string = "");
+struct DOCTEST_INTERFACE ResultBuilder : public AssertData
+{
+  ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                const char* exception_type = "", const String& exception_string = "");
 
-        void setResult(const Result& res);
+  ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                const char* exception_type, const Contains& exception_string);
 
-        template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
-            m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(m_failed || getContextOptions()->success)
-                m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
-        }
+  void setResult(const Result& res);
 
-        template <typename L>
-        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val) {
-            m_failed = !val;
+  template <int comparison, typename L, typename R>
+  DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
+                                      const DOCTEST_REF_WRAP(R) rhs) {
+    m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+    if (m_failed || getContextOptions()->success) {
+      m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+    }
+    return !m_failed;
+  }
 
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
-                m_failed = !m_failed;
+  template <typename L>
+  DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
+    m_failed = !val;
 
-            if(m_failed || getContextOptions()->success)
-                m_decomp = toString(val);
-        }
+    if (m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
+      m_failed = !m_failed;
+    }
 
-        void translateException();
+    if (m_failed || getContextOptions()->success) {
+      m_decomp = (DOCTEST_STRINGIFY(val));
+    }
 
-        bool log();
-        void react() const;
-    };
+    return !m_failed;
+  }
 
-    namespace assertAction {
-        enum Enum
-        {
-            nothing     = 0,
-            dbgbreak    = 1,
-            shouldthrow = 2
-        };
-    } // namespace assertAction
+  void translateException();
 
-    DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
+  bool log();
+  void react() const;
+};
 
-    DOCTEST_INTERFACE void decomp_assert(assertType::Enum at, const char* file, int line,
-                                         const char* expr, Result result);
+namespace assertAction {
+enum Enum
+{
+  nothing     = 0,
+  dbgbreak    = 1,
+  shouldthrow = 2
+};
+} // namespace assertAction
+
+DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
+
+DOCTEST_INTERFACE bool decomp_assert(assertType::Enum at, const char* file, int line,
+                                     const char* expr, const Result& result);
 
 #define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                        \
     do {                                                                                           \
@@ -1353,7 +1704,7 @@ namespace detail {
                 if(checkIfShouldThrow(at))                                                         \
                     throwException();                                                              \
             }                                                                                      \
-            return;                                                                                \
+            return !failed;                                                                        \
         }                                                                                          \
     } while(false)
 
@@ -1367,167 +1718,155 @@ namespace detail {
     if(rb.m_failed && checkIfShouldThrow(at))                                                      \
     throwException()
 
-    template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE void binary_assert(assertType::Enum at, const char* file, int line,
-                                        const char* expr, const DOCTEST_REF_WRAP(L) lhs,
-                                        const DOCTEST_REF_WRAP(R) rhs) {
-        bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
+template <int comparison, typename L, typename R>
+DOCTEST_NOINLINE bool binary_assert(assertType::Enum at, const char* file, int line,
+                                    const char* expr, const DOCTEST_REF_WRAP(L) lhs,
+                                    const DOCTEST_REF_WRAP(R) rhs) {
+  bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-        DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
-    }
+  // ###################################################################################
+  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+  // ###################################################################################
+  DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+  DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+  return !failed;
+}
 
-    template <typename L>
-    DOCTEST_NOINLINE void unary_assert(assertType::Enum at, const char* file, int line,
-                                       const char* expr, const DOCTEST_REF_WRAP(L) val) {
-        bool failed = !val;
+template <typename L>
+DOCTEST_NOINLINE bool unary_assert(assertType::Enum at, const char* file, int line,
+                                   const char* expr, const DOCTEST_REF_WRAP(L) val) {
+  bool failed = !val;
 
-        if(at & assertType::is_false) //!OCLINT bitwise operator in conditional
-            failed = !failed;
+  if(at & assertType::is_false) //!OCLINT bitwise operator in conditional
+    failed = !failed;
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(toString(val));
-        DOCTEST_ASSERT_IN_TESTS(toString(val));
-    }
+  // ###################################################################################
+  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+  // ###################################################################################
+  DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
+  DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
+  return !failed;
+}
 
-    struct DOCTEST_INTERFACE IExceptionTranslator
-    {
-        IExceptionTranslator();
-        virtual ~IExceptionTranslator();
-        virtual bool translate(String&) const = 0;
-    };
+struct DOCTEST_INTERFACE IExceptionTranslator
+{
+  DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
+  virtual bool translate(String&) const = 0;
+};
 
-    template <typename T>
-    class ExceptionTranslator : public IExceptionTranslator //!OCLINT destructor of virtual class
-    {
-    public:
-        explicit ExceptionTranslator(String (*translateFunction)(T))
-                : m_translateFunction(translateFunction) {}
+template <typename T>
+class ExceptionTranslator : public IExceptionTranslator //!OCLINT destructor of virtual class
+{
+public:
+  explicit ExceptionTranslator(String (*translateFunction)(T))
+      : m_translateFunction(translateFunction) {}
 
-        bool translate(String& res) const override {
+  bool translate(String& res) const override {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-            try {
-                throw; // lgtm [cpp/rethrow-no-exception]
-                // cppcheck-suppress catchExceptionByValue
-            } catch(T ex) {                    // NOLINT
-                res = m_translateFunction(ex); //!OCLINT parameter reassignment
-                return true;
-            } catch(...) {} //!OCLINT -  empty catch statement
-#endif                      // DOCTEST_CONFIG_NO_EXCEPTIONS
-            ((void)res);    // to silence -Wunused-parameter
-            return false;
-        }
+    try {
+      throw; // lgtm [cpp/rethrow-no-exception]
+             // cppcheck-suppress catchExceptionByValue
+    } catch(const T& ex) {
+      res = m_translateFunction(ex); //!OCLINT parameter reassignment
+      return true;
+    } catch(...) {}         //!OCLINT -  empty catch statement
+#endif                              // DOCTEST_CONFIG_NO_EXCEPTIONS
+    static_cast<void>(res); // to silence -Wunused-parameter
+    return false;
+  }
 
-    private:
-        String (*m_translateFunction)(T);
-    };
+private:
+  String (*m_translateFunction)(T);
+};
 
-    DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator* et);
+DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator* et);
 
-    template <bool C>
-    struct StringStreamBase
-    {
-        template <typename T>
-        static void convert(std::ostream* s, const T& in) {
-            *s << toString(in);
-        }
+// ContextScope base class used to allow implementing methods of ContextScope
+// that don't depend on the template parameter in doctest.cpp.
+struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+  ContextScopeBase(const ContextScopeBase&) = delete;
 
-        // always treat char* as a string in this context - no matter
-        // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
-        static void convert(std::ostream* s, const char* in) { *s << String(in); }
-    };
+  ContextScopeBase& operator=(const ContextScopeBase&) = delete;
+  ContextScopeBase& operator=(ContextScopeBase&&) = delete;
 
-    template <>
-    struct StringStreamBase<true>
-    {
-        template <typename T>
-        static void convert(std::ostream* s, const T& in) {
-            *s << in;
-        }
-    };
+  ~ContextScopeBase() override = default;
 
-    template <typename T>
-    struct StringStream : public StringStreamBase<has_insertion_operator<T>::value>
-    {};
+protected:
+  ContextScopeBase();
+  ContextScopeBase(ContextScopeBase&& other) noexcept;
 
-    template <typename T>
-    void toStream(std::ostream* s, const T& value) {
-        StringStream<T>::convert(s, value);
+  void destroy();
+  bool need_to_destroy{true};
+};
+
+template <typename L> class ContextScope : public ContextScopeBase
+{
+  L lambda_;
+
+public:
+  explicit ContextScope(const L &lambda) : lambda_(lambda) {}
+  explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
+
+  ContextScope(const ContextScope&) = delete;
+  ContextScope(ContextScope&&) noexcept = default;
+
+  ContextScope& operator=(const ContextScope&) = delete;
+  ContextScope& operator=(ContextScope&&) = delete;
+
+  void stringify(std::ostream* s) const override { lambda_(s); }
+
+  ~ContextScope() override {
+    if (need_to_destroy) {
+      destroy();
     }
+  }
+};
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char* in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, const char* in);
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* s, bool in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, float in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, double in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, double long in);
+struct DOCTEST_INTERFACE MessageBuilder : public MessageData
+{
+  std::ostream* m_stream;
+  bool          logged = false;
 
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char signed in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int short in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int short unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long long unsigned in);
+  MessageBuilder(const char* file, int line, assertType::Enum severity);
 
-    // ContextScope base class used to allow implementing methods of ContextScope 
-    // that don't depend on the template parameter in doctest.cpp.
-    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
-    protected:
-        ContextScopeBase();
+  MessageBuilder(const MessageBuilder&) = delete;
+  MessageBuilder(MessageBuilder&&) = delete;
 
-        void destroy();
-    };
+  MessageBuilder& operator=(const MessageBuilder&) = delete;
+  MessageBuilder& operator=(MessageBuilder&&) = delete;
 
-    template <typename L> class DOCTEST_INTERFACE ContextScope : public ContextScopeBase
-    {
-        const L &lambda_;
+  ~MessageBuilder();
 
-    public:
-        explicit ContextScope(const L &lambda) : lambda_(lambda) {}
+  // the preferred way of chaining parameters for stringification
+  DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+  template <typename T>
+  MessageBuilder& operator,(const T& in) {
+    *m_stream << (DOCTEST_STRINGIFY(in));
+    return *this;
+  }
+  DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-        ContextScope(ContextScope &&other) : lambda_(other.lambda_) {}
+  // kept here just for backwards-compatibility - the comma operator should be preferred now
+  template <typename T>
+  MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
 
-        void stringify(std::ostream* s) const override { lambda_(s); }
+  // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
+  // the `,` operator will be called last which is not what we want and thus the `*` operator
+  // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
+  // an operator of the MessageBuilder class is called first before the rest of the parameters
+  template <typename T>
+  MessageBuilder& operator*(const T& in) { return this->operator,(in); }
 
-        ~ContextScope() override { destroy(); }
-    };
+  bool log();
+  void react();
+};
 
-    struct DOCTEST_INTERFACE MessageBuilder : public MessageData
-    {
-        std::ostream* m_stream;
-
-        MessageBuilder(const char* file, int line, assertType::Enum severity);
-        MessageBuilder() = delete;
-        ~MessageBuilder();
-
-        template <typename T>
-        MessageBuilder& operator<<(const T& in) {
-            toStream(m_stream, in);
-            return *this;
-        }
-
-        bool log();
-        void react();
-    };
-    
-    template <typename L>
-    ContextScope<L> MakeContextScope(const L &lambda) {
-        return ContextScope<L>(lambda);
-    }
+template <typename L>
+ContextScope<L> MakeContextScope(const L &lambda) {
+  return ContextScope<L>(lambda);
+}
 } // namespace detail
 
 #define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
@@ -1543,6 +1882,8 @@ namespace detail {
 DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
 DOCTEST_DEFINE_DECORATOR(description, const char*, "");
 DOCTEST_DEFINE_DECORATOR(skip, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
 DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
 DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
@@ -1550,11 +1891,11 @@ DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
 template <typename T>
 int registerExceptionTranslator(String (*translateFunction)(T)) {
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
-    static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    detail::registerExceptionTranslatorImpl(&exceptionTranslator);
-    return 0;
+  DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
+  static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
+  DOCTEST_CLANG_SUPPRESS_WARNING_POP
+  detail::registerExceptionTranslatorImpl(&exceptionTranslator);
+  return 0;
 }
 
 } // namespace doctest
@@ -1569,166 +1910,191 @@ namespace doctest {
 #else  // DOCTEST_CONFIG_DISABLE
 template <typename T>
 int registerExceptionTranslator(String (*)(T)) {
-    return 0;
+  return 0;
 }
 #endif // DOCTEST_CONFIG_DISABLE
 
 namespace detail {
-    typedef void (*assert_handler)(const AssertData&);
-    struct ContextState;
+using assert_handler = void (*)(const AssertData&);
+struct ContextState;
 } // namespace detail
 
 class DOCTEST_INTERFACE Context
 {
-    detail::ContextState* p;
+  detail::ContextState* p;
 
-    void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
+  void parseArgs(int argc, const char* const* argv, bool withDefaults = false);
 
 public:
-    explicit Context(int argc = 0, const char* const* argv = nullptr);
+  explicit Context(int argc = 0, const char* const* argv = nullptr);
 
-    ~Context();
+  Context(const Context&) = delete;
+  Context(Context&&) = delete;
 
-    void applyCommandLine(int argc, const char* const* argv);
+  Context& operator=(const Context&) = delete;
+  Context& operator=(Context&&) = delete;
 
-    void addFilter(const char* filter, const char* value);
-    void clearFilters();
-    void setOption(const char* option, int value);
-    void setOption(const char* option, const char* value);
+  ~Context(); // NOLINT(performance-trivially-destructible)
 
-    bool shouldExit();
+  void applyCommandLine(int argc, const char* const* argv);
 
-    void setAsDefaultForAssertsOutOfTestCases();
+  void addFilter(const char* filter, const char* value);
+  void clearFilters();
+  void setOption(const char* option, bool value);
+  void setOption(const char* option, int value);
+  void setOption(const char* option, const char* value);
 
-    void setAssertHandler(detail::assert_handler ah);
+  bool shouldExit();
 
-    int run();
+  void setAsDefaultForAssertsOutOfTestCases();
+
+  void setAssertHandler(detail::assert_handler ah);
+
+  void setCout(std::ostream* out);
+
+  int run();
 };
 
 namespace TestCaseFailureReason {
-    enum Enum
-    {
-        None                     = 0,
-        AssertFailure            = 1,   // an assertion has failed in the test case
-        Exception                = 2,   // test case threw an exception
-        Crash                    = 4,   // a crash...
-        TooManyFailedAsserts     = 8,   // the abort-after option
-        Timeout                  = 16,  // see the timeout decorator
-        ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
-        ShouldHaveFailedAndDid   = 64,  // see the should_fail decorator
-        DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
-        FailedExactlyNumTimes    = 256, // see the expected_failures decorator
-        CouldHaveFailedAndDid    = 512  // see the may_fail decorator
-    };
+enum Enum
+{
+  None                     = 0,
+  AssertFailure            = 1,   // an assertion has failed in the test case
+  Exception                = 2,   // test case threw an exception
+  Crash                    = 4,   // a crash...
+  TooManyFailedAsserts     = 8,   // the abort-after option
+  Timeout                  = 16,  // see the timeout decorator
+  ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
+  ShouldHaveFailedAndDid   = 64,  // see the should_fail decorator
+  DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
+  FailedExactlyNumTimes    = 256, // see the expected_failures decorator
+  CouldHaveFailedAndDid    = 512  // see the may_fail decorator
+};
 } // namespace TestCaseFailureReason
 
 struct DOCTEST_INTERFACE CurrentTestCaseStats
 {
-    int    numAssertsCurrentTest;
-    int    numAssertsFailedCurrentTest;
-    double seconds;
-    int    failure_flags; // use TestCaseFailureReason::Enum
+  int    numAssertsCurrentTest;
+  int    numAssertsFailedCurrentTest;
+  double seconds;
+  int    failure_flags; // use TestCaseFailureReason::Enum
+  bool   testCaseSuccess;
 };
 
 struct DOCTEST_INTERFACE TestCaseException
 {
-    String error_string;
-    bool   is_crash;
+  String error_string;
+  bool   is_crash;
 };
 
 struct DOCTEST_INTERFACE TestRunStats
 {
-    unsigned numTestCases;
-    unsigned numTestCasesPassingFilters;
-    unsigned numTestSuitesPassingFilters;
-    unsigned numTestCasesFailed;
-    int      numAsserts;
-    int      numAssertsFailed;
+  unsigned numTestCases;
+  unsigned numTestCasesPassingFilters;
+  unsigned numTestSuitesPassingFilters;
+  unsigned numTestCasesFailed;
+  int      numAsserts;
+  int      numAssertsFailed;
 };
 
 struct QueryData
 {
-    const TestRunStats* run_stats = nullptr;
-    String*             data      = nullptr;
-    unsigned            num_data  = 0;
+  const TestRunStats*  run_stats = nullptr;
+  const TestCaseData** data      = nullptr;
+  unsigned             num_data  = 0;
 };
 
 struct DOCTEST_INTERFACE IReporter
 {
-    // The constructor has to accept "const ContextOptions&" as a single argument
-    // which has most of the options for the run + a pointer to the stdout stream
-    // Reporter(const ContextOptions& in)
+  // The constructor has to accept "const ContextOptions&" as a single argument
+  // which has most of the options for the run + a pointer to the stdout stream
+  // Reporter(const ContextOptions& in)
 
-    // called when a query should be reported (listing test cases, printing the version, etc.)
-    virtual void report_query(const QueryData&) = 0;
+  // called when a query should be reported (listing test cases, printing the version, etc.)
+  virtual void report_query(const QueryData&) = 0;
 
-    // called when the whole test run starts
-    virtual void test_run_start() = 0;
-    // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-    virtual void test_run_end(const TestRunStats&) = 0;
+  // called when the whole test run starts
+  virtual void test_run_start() = 0;
+  // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+  virtual void test_run_end(const TestRunStats&) = 0;
 
-    // called when a test case is started (safe to cache a pointer to the input)
-    virtual void test_case_start(const TestCaseData&) = 0;
-    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
-    virtual void test_case_reenter(const TestCaseData&) = 0;
-    // called when a test case has ended
-    virtual void test_case_end(const CurrentTestCaseStats&) = 0;
+  // called when a test case is started (safe to cache a pointer to the input)
+  virtual void test_case_start(const TestCaseData&) = 0;
+  // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+  virtual void test_case_reenter(const TestCaseData&) = 0;
+  // called when a test case has ended
+  virtual void test_case_end(const CurrentTestCaseStats&) = 0;
 
-    // called when an exception is thrown from the test case (or it crashes)
-    virtual void test_case_exception(const TestCaseException&) = 0;
+  // called when an exception is thrown from the test case (or it crashes)
+  virtual void test_case_exception(const TestCaseException&) = 0;
 
-    // called whenever a subcase is entered (don't cache pointers to the input)
-    virtual void subcase_start(const SubcaseSignature&) = 0;
-    // called whenever a subcase is exited (don't cache pointers to the input)
-    virtual void subcase_end() = 0;
+  // called whenever a subcase is entered (don't cache pointers to the input)
+  virtual void subcase_start(const SubcaseSignature&) = 0;
+  // called whenever a subcase is exited (don't cache pointers to the input)
+  virtual void subcase_end() = 0;
 
-    // called for each assert (don't cache pointers to the input)
-    virtual void log_assert(const AssertData&) = 0;
-    // called for each message (don't cache pointers to the input)
-    virtual void log_message(const MessageData&) = 0;
+  // called for each assert (don't cache pointers to the input)
+  virtual void log_assert(const AssertData&) = 0;
+  // called for each message (don't cache pointers to the input)
+  virtual void log_message(const MessageData&) = 0;
 
-    // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-    // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-    virtual void test_case_skipped(const TestCaseData&) = 0;
+  // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
+  // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
+  virtual void test_case_skipped(const TestCaseData&) = 0;
 
-    // doctest will not be managing the lifetimes of reporters given to it but this would still be nice to have
-    virtual ~IReporter();
+  DOCTEST_DECLARE_INTERFACE(IReporter)
 
-    // can obtain all currently active contexts and stringify them if one wishes to do so
-    static int                         get_num_active_contexts();
-    static const IContextScope* const* get_active_contexts();
+  // can obtain all currently active contexts and stringify them if one wishes to do so
+  static int                         get_num_active_contexts();
+  static const IContextScope* const* get_active_contexts();
 
-    // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-    static int           get_num_stringified_contexts();
-    static const String* get_stringified_contexts();
+  // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
+  static int           get_num_stringified_contexts();
+  static const String* get_stringified_contexts();
 };
 
 namespace detail {
-    typedef IReporter* (*reporterCreatorFunc)(const ContextOptions&);
+using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
 
-    DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
+DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
 
-    template <typename Reporter>
-    IReporter* reporterCreator(const ContextOptions& o) {
-        return new Reporter(o);
-    }
+template <typename Reporter>
+IReporter* reporterCreator(const ContextOptions& o) {
+  return new Reporter(o);
+}
 } // namespace detail
 
 template <typename Reporter>
 int registerReporter(const char* name, int priority, bool isReporter) {
-    detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
-    return 0;
+  detail::registerReporterImpl(name, priority, detail::reporterCreator<Reporter>, isReporter);
+  return 0;
 }
 } // namespace doctest
 
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_EMPTY [] { return false; }()
+#else
+#define DOCTEST_FUNC_EMPTY (void)0
+#endif
+
 // if registering is not disabled
-#if !defined(DOCTEST_CONFIG_DISABLE)
+#ifndef DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_SCOPE_BEGIN [&]
+#define DOCTEST_FUNC_SCOPE_END ()
+#define DOCTEST_FUNC_SCOPE_RET(v) return v
+#else
+#define DOCTEST_FUNC_SCOPE_BEGIN do
+#define DOCTEST_FUNC_SCOPE_END while(false)
+#define DOCTEST_FUNC_SCOPE_RET(v) (void)0
+#endif
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_AND_REACT(b)                                                            \
-    if(b.log())                                                                                    \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
-    b.react()
+#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
+    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
+    b.react();                                                                                     \
+    DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
 #ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #define DOCTEST_WRAP_IN_TRY(x) x;
@@ -1736,41 +2102,40 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_WRAP_IN_TRY(x)                                                                     \
     try {                                                                                          \
         x;                                                                                         \
-    } catch(...) { _DOCTEST_RB.translateException(); }
+    } catch(...) { DOCTEST_RB.translateException(); }
 #endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #ifdef DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(x)                                                                    \
+#define DOCTEST_CAST_TO_VOID(...)                                                                  \
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
-    static_cast<void>(x);                                                                          \
+    static_cast<void>(__VA_ARGS__);                                                                \
     DOCTEST_GCC_SUPPRESS_WARNING_POP
 #else // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(x) x;
+#define DOCTEST_CAST_TO_VOID(...) __VA_ARGS__;
 #endif // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 
 // registers the test by initializing a dummy var with a function
 #define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =              \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
             doctest::detail::regTest(                                                              \
                     doctest::detail::TestCase(                                                     \
                             f, __FILE__, __LINE__,                                                 \
                             doctest_detail_test_suite_ns::getCurrentTestSuite()) *                 \
-                    decorators);                                                                   \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()
+                    decorators))
 
 #define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace {                                                                                    \
+    namespace { /* NOLINT */                                                                       \
         struct der : public base                                                                   \
         {                                                                                          \
             void f();                                                                              \
         };                                                                                         \
-        static void func() {                                                                       \
+        static inline DOCTEST_NOINLINE void func() {                                               \
             der v;                                                                                 \
             v.f();                                                                                 \
         }                                                                                          \
         DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                 \
     }                                                                                              \
-    inline DOCTEST_NOINLINE void der::f()
+    inline DOCTEST_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
 
 #define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
     static void f();                                                                               \
@@ -1779,18 +2144,18 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                        \
     static doctest::detail::funcType proxy() { return f; }                                         \
-    DOCTEST_REGISTER_FUNCTION(inline const, proxy(), decorators)                                   \
+    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                         \
     static void f()
 
 // for registering tests
 #define DOCTEST_TEST_CASE(decorators)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests in classes - requires C++17 for inline variables!
-#if __cplusplus >= 201703L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 12, 0) && _MSVC_LANG >= 201703L)
+#if DOCTEST_CPLUSPLUS >= 201703L
 #define DOCTEST_TEST_CASE_CLASS(decorators)                                                        \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_),          \
-                                                  DOCTEST_ANONYMOUS(_DOCTEST_ANON_PROXY_),         \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_),           \
+                                                  DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_),          \
                                                   decorators)
 #else // DOCTEST_TEST_CASE_CLASS
 #define DOCTEST_TEST_CASE_CLASS(...)                                                               \
@@ -1799,26 +2164,25 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 // for registering tests with a fixture
 #define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c,                           \
+                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)                                                           \
-    template <>                                                                                    \
-    inline const char* type_to_string<__VA_ARGS__>() {                                             \
-        return "<" #__VA_ARGS__ ">";                                                               \
-    }
-#define DOCTEST_TYPE_TO_STRING(...)                                                                \
-    namespace doctest { namespace detail {                                                         \
-            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__)                                               \
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                        \
+    namespace doctest {                                                                            \
+        template <>                                                                                \
+        inline String toString<__VA_ARGS__>() {                                                    \
+            return str;                                                                            \
         }                                                                                          \
     }                                                                                              \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    static_assert(true, "")
+
+#define DOCTEST_TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING_AS(#__VA_ARGS__, __VA_ARGS__)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                 \
     template <typename T>                                                                          \
     static void func();                                                                            \
-    namespace {                                                                                    \
+    namespace { /* NOLINT */                                                                       \
         template <typename Tuple>                                                                  \
         struct iter;                                                                               \
         template <typename Type, typename... Rest>                                                 \
@@ -1827,7 +2191,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
             iter(const char* file, unsigned line, int index) {                                     \
                 doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
                                             doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::detail::type_to_string<Type>(),               \
+                                            doctest::toString<Type>(),                             \
                                             int(line) * 1000 + index)                              \
                                          * dec);                                                   \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
@@ -1844,20 +2208,20 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                              \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR),                      \
-                                           DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+                                           DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) =                                         \
-        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0));\
-    DOCTEST_GLOBAL_NO_WARNINGS_END()
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
+        doctest::detail::instantiationHelper(                                                      \
+            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__) \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);             \
@@ -1866,23 +2230,25 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     static void anon()
 
 #define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                    \
-    DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
+    DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
 #define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
+    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
                doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
     namespace ns_name { namespace doctest_detail_test_suite_ns {                                   \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() {            \
+            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() noexcept {   \
                 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                      \
                 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                \
-                static doctest::detail::TestSuite data;                                            \
+                DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")             \
+                static doctest::detail::TestSuite data{};                                          \
                 static bool                       inited = false;                                  \
                 DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                  \
                 DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                 \
+                DOCTEST_GCC_SUPPRESS_WARNING_POP                                                   \
                 if(!inited) {                                                                      \
                     data* decorators;                                                              \
                     inited = true;                                                                 \
@@ -1894,79 +2260,79 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     namespace ns_name
 
 #define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
+    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
 #define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators);              \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
+    static_assert(true, "")
 
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * "");                      \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+    using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
     inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =                     \
-            doctest::registerExceptionTranslator(translatorName);                                  \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerExceptionTranslator(translatorName))                                  \
     doctest::String translatorName(signature)
 
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_),       \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_),        \
                                                signature)
 
 // for registering reporters
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) =                       \
-            doctest::registerReporter<reporter>(name, priority, true);                             \
-    DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerReporter<reporter>(name, priority, true))                             \
+    static_assert(true, "")
 
 // for registering listeners
 #define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) =                       \
-            doctest::registerReporter<reporter>(name, priority, false);                            \
-    DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for logging
-#define DOCTEST_INFO(expression)                                                                   \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_),  \
-                      DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_), expression)
-
-#define DOCTEST_INFO_IMPL(lambda_name, mb_name, s_name, expression)                                \
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4626)                                                  \
-    auto lambda_name = [&](std::ostream* s_name) {                                                 \
-        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
-        mb_name.m_stream = s_name;                                                                 \
-        mb_name << expression;                                                                     \
-    };                                                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                              \
-    auto DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(lambda_name)
-
-#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
-
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                               \
-    do {                                                                                           \
-        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb << x;                                                                                   \
-        DOCTEST_ASSERT_LOG_AND_REACT(mb);                                                          \
-    } while((void)0, 0)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerReporter<reporter>(name, priority, false))                            \
+    static_assert(true, "")
 
 // clang-format off
-#define DOCTEST_ADD_MESSAGE_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
-#define DOCTEST_ADD_FAIL_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
+// for logging - disabling formatting because it's important to have these on 2 separate lines - see PR #557
+#define DOCTEST_INFO(...)                                                                          \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
+                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
+                      __VA_ARGS__)
 // clang-format on
 
-#define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
+    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
+        [&](std::ostream* s_name) {                                                                \
+        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
+        mb_name.m_stream = s_name;                                                                 \
+        mb_name * __VA_ARGS__;                                                                     \
+    })
+
+#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
+
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
+        mb * __VA_ARGS__;                                                                          \
+        if(mb.log())                                                                               \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        mb.react();                                                                                \
+    } DOCTEST_FUNC_SCOPE_END
+
+// clang-format off
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+// clang-format on
+
+#define DOCTEST_MESSAGE(...) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL_CHECK(...) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL(...) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, __VA_ARGS__)
 
 #define DOCTEST_TO_LVALUE(...) __VA_ARGS__ // Not removed to keep backwards compatibility.
 
@@ -1974,18 +2340,37 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,         \
+    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
+    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
                                                __LINE__, #__VA_ARGS__);                            \
-    DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.setResult(                                                     \
+    DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-            << __VA_ARGS__))                                                                       \
-    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                      \
+            << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
+    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                    \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 #define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    do {                                                                                           \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } while((void)0, 0)
+    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        DOCTEST_WRAP_IN_TRY(                                                                       \
+                DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
+                        __VA_ARGS__))                                                              \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -1999,6 +2384,14 @@ int registerReporter(const char* name, int priority, bool isReporter) {
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
                     << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
+            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
+                                  #__VA_ARGS__, __VA_ARGS__)
+
 #endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_WARN, __VA_ARGS__)
@@ -2009,121 +2402,13 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_REQUIRE_FALSE, __VA_ARGS__)
 
 // clang-format off
-#define DOCTEST_WARN_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN, cond); } while((void)0, 0)
-#define DOCTEST_CHECK_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK, cond); } while((void)0, 0)
-#define DOCTEST_REQUIRE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE, cond); } while((void)0, 0)
-#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN_FALSE, cond); } while((void)0, 0)
-#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } while((void)0, 0)
-#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } while((void)0, 0)
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
 // clang-format on
-
-#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                  \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(const doctest::detail::remove_const<                                           \
-                    doctest::detail::remove_reference<__VA_ARGS__>::type>::type&) {                \
-                _DOCTEST_RB.translateException();                                                  \
-                _DOCTEST_RB.m_threw_as = true;                                                     \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
-
-#define DOCTEST_ASSERT_THROWS_WITH(expr, assert_type, ...)                                         \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, "", __VA_ARGS__);          \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
-
-#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                  \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #expr);                               \
-        try {                                                                                      \
-            DOCTEST_CAST_TO_VOID(expr)                                                             \
-        } catch(...) { _DOCTEST_RB.translateException(); }                                         \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-// clang-format off
-#define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_WARN_THROWS, "")
-#define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_CHECK_THROWS, "")
-#define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_REQUIRE_THROWS, "")
-
-#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_AS, "", __VA_ARGS__)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_AS, "", __VA_ARGS__)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_AS, "", __VA_ARGS__)
-
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_WARN_THROWS_WITH, __VA_ARGS__)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_CHECK_THROWS_WITH, __VA_ARGS__)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_REQUIRE_THROWS_WITH, __VA_ARGS__)
-
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_WITH_AS, message, __VA_ARGS__)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_WITH_AS, message, __VA_ARGS__)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_WITH_AS, message, __VA_ARGS__)
-
-#define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
-#define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
-#define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS_WITH(expr, with); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS_WITH(expr, with); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS_WITH(expr, with); } while((void)0, 0)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex); } while((void)0, 0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_NOTHROW(expr); } while((void)0, 0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_NOTHROW(expr); } while((void)0, 0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_NOTHROW(expr); } while((void)0, 0)
-// clang-format on
-
-#ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(          \
-                        __VA_ARGS__))                                                              \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(__VA_ARGS__))                                 \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
-    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
-
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
-                                  #__VA_ARGS__, __VA_ARGS__)
-
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, eq, __VA_ARGS__)
 #define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, eq, __VA_ARGS__)
@@ -2151,75 +2436,350 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, __VA_ARGS__)
 #define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, __VA_ARGS__)
 
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                  \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        if(!doctest::getContextOptions()->no_throw) {                                              \
+            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
+                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
+            try {                                                                                  \
+                DOCTEST_CAST_TO_VOID(expr)                                                         \
+            } catch(const typename doctest::detail::types::remove_const<                           \
+                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
+                DOCTEST_RB.translateException();                                                   \
+                DOCTEST_RB.m_threw_as = true;                                                      \
+            } catch(...) { DOCTEST_RB.translateException(); }                                      \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
+        } else { /* NOLINT(*-else-after-return) */                                                 \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
+        }                                                                                          \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        if(!doctest::getContextOptions()->no_throw) {                                              \
+            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
+                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
+            try {                                                                                  \
+                DOCTEST_CAST_TO_VOID(expr)                                                         \
+            } catch(...) { DOCTEST_RB.translateException(); }                                      \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
+        } else { /* NOLINT(*-else-after-return) */                                                 \
+           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
+        }                                                                                          \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        try {                                                                                      \
+            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
+        } catch(...) { DOCTEST_RB.translateException(); }                                          \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
+
+// clang-format off
+#define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_CHECK_THROWS, "")
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_REQUIRE_THROWS, "")
+
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_AS, "", __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_WARN_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_CHECK_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_REQUIRE_THROWS_WITH, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_WITH_AS, message, __VA_ARGS__)
+
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_WARN_NOTHROW, __VA_ARGS__)
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_CHECK_NOTHROW, __VA_ARGS__)
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_REQUIRE_NOTHROW, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+// clang-format on
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+// =================================================================================================
+// == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
+// == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
+// =================================================================================================
+#else // DOCTEST_CONFIG_DISABLE
+
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
+    namespace /* NOLINT */ {                                                                       \
+        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
+        struct der : public base                                                                   \
+        { void f(); };                                                                             \
+    }                                                                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
+
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    static inline void f()
+
+// for registering tests
+#define DOCTEST_TEST_CASE(name)                                                                    \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests in classes
+#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests with a fixture
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x,                           \
+                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for converting types to strings without the <typeinfo> header and demangling
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...) static_assert(true, "")
+#define DOCTEST_TYPE_TO_STRING(...) static_assert(true, "")
+
+// for typed tests
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
+    template <typename type>                                                                       \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
+    template <typename type>                                                                       \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...) static_assert(true, "")
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...) static_assert(true, "")
+
+// for subcases
+#define DOCTEST_SUBCASE(name)
+
+// for a testsuite block
+#define DOCTEST_TEST_SUITE(name) namespace // NOLINT
+
+// for starting a testsuite block
+#define DOCTEST_TEST_SUITE_BEGIN(name) static_assert(true, "")
+
+// for ending a testsuite block
+#define DOCTEST_TEST_SUITE_END using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
+
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    static inline doctest::String DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_)(signature)
+
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+
+#define DOCTEST_INFO(...) (static_cast<void>(0))
+#define DOCTEST_CAPTURE(x) (static_cast<void>(0))
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_MESSAGE(...) (static_cast<void>(0))
+#define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
+#define DOCTEST_FAIL(...) (static_cast<void>(0))
+
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
+ && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+
+#define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_CHECK_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+
+namespace doctest {
+namespace detail {
+#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
+    template <typename L, typename R>                                                              \
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+
+DOCTEST_RELATIONAL_OP(eq, ==)
+DOCTEST_RELATIONAL_OP(ne, !=)
+DOCTEST_RELATIONAL_OP(lt, <)
+DOCTEST_RELATIONAL_OP(gt, >)
+DOCTEST_RELATIONAL_OP(le, <=)
+DOCTEST_RELATIONAL_OP(ge, >=)
+} // namespace detail
+} // namespace doctest
+
+#define DOCTEST_WARN_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_CHECK_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_WARN_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_CHECK_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_WARN_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_WARN_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_WARN_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_WARN_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_WARN_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+
+#define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#else // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#define DOCTEST_WARN(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#endif // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#endif // DOCTEST_CONFIG_DISABLE
+
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#undef DOCTEST_WARN_THROWS
-#undef DOCTEST_CHECK_THROWS
-#undef DOCTEST_REQUIRE_THROWS
-#undef DOCTEST_WARN_THROWS_AS
-#undef DOCTEST_CHECK_THROWS_AS
-#undef DOCTEST_REQUIRE_THROWS_AS
-#undef DOCTEST_WARN_THROWS_WITH
-#undef DOCTEST_CHECK_THROWS_WITH
-#undef DOCTEST_REQUIRE_THROWS_WITH
-#undef DOCTEST_WARN_THROWS_WITH_AS
-#undef DOCTEST_CHECK_THROWS_WITH_AS
-#undef DOCTEST_REQUIRE_THROWS_WITH_AS
-#undef DOCTEST_WARN_NOTHROW
-#undef DOCTEST_CHECK_NOTHROW
-#undef DOCTEST_REQUIRE_NOTHROW
-
-#undef DOCTEST_WARN_THROWS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_MESSAGE
-#undef DOCTEST_WARN_THROWS_AS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_AS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#undef DOCTEST_WARN_THROWS_WITH_MESSAGE
-#undef DOCTEST_CHECK_THROWS_WITH_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_WITH_MESSAGE
-#undef DOCTEST_WARN_THROWS_WITH_AS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE
-#undef DOCTEST_WARN_NOTHROW_MESSAGE
-#undef DOCTEST_CHECK_NOTHROW_MESSAGE
-#undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
-
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
-
+#define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
+    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -2234,162 +2794,54 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #undef DOCTEST_REQUIRE_UNARY
 #undef DOCTEST_REQUIRE_UNARY_FALSE
 
+#define DOCTEST_REQUIRE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_EQ DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
+#define DOCTEST_WARN_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-// =================================================================================================
-// == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
-// == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
-// =================================================================================================
-#else // DOCTEST_CONFIG_DISABLE
-
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace {                                                                                    \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : public base                                                                   \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
-
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    static inline void f()
-
-// for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for registering tests in classes
-#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)
-
-// for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
-    template <typename type>                                                                       \
-    inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
-
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
-    inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
-
-#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for subcases
-#define DOCTEST_SUBCASE(name)
-
-// for a testsuite block
-#define DOCTEST_TEST_SUITE(name) namespace
-
-// for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    static inline doctest::String DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)(signature)
-
-#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
-#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)
-
-#define DOCTEST_INFO(x) ((void)0)
-#define DOCTEST_CAPTURE(x) ((void)0)
-#define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
-#define DOCTEST_MESSAGE(x) ((void)0)
-#define DOCTEST_FAIL_CHECK(x) ((void)0)
-#define DOCTEST_FAIL(x) ((void)0)
-
-#define DOCTEST_WARN(...) ((void)0)
-#define DOCTEST_CHECK(...) ((void)0)
-#define DOCTEST_REQUIRE(...) ((void)0)
-#define DOCTEST_WARN_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_FALSE(...) ((void)0)
-
-#define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
-
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) ((void)0)
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
-
-#define DOCTEST_WARN_EQ(...) ((void)0)
-#define DOCTEST_CHECK_EQ(...) ((void)0)
-#define DOCTEST_REQUIRE_EQ(...) ((void)0)
-#define DOCTEST_WARN_NE(...) ((void)0)
-#define DOCTEST_CHECK_NE(...) ((void)0)
-#define DOCTEST_REQUIRE_NE(...) ((void)0)
-#define DOCTEST_WARN_GT(...) ((void)0)
-#define DOCTEST_CHECK_GT(...) ((void)0)
-#define DOCTEST_REQUIRE_GT(...) ((void)0)
-#define DOCTEST_WARN_LT(...) ((void)0)
-#define DOCTEST_CHECK_LT(...) ((void)0)
-#define DOCTEST_REQUIRE_LT(...) ((void)0)
-#define DOCTEST_WARN_GE(...) ((void)0)
-#define DOCTEST_CHECK_GE(...) ((void)0)
-#define DOCTEST_REQUIRE_GE(...) ((void)0)
-#define DOCTEST_WARN_LE(...) ((void)0)
-#define DOCTEST_CHECK_LE(...) ((void)0)
-#define DOCTEST_REQUIRE_LE(...) ((void)0)
-
-#define DOCTEST_WARN_UNARY(...) ((void)0)
-#define DOCTEST_CHECK_UNARY(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY(...) ((void)0)
-#define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
-
-#endif // DOCTEST_CONFIG_DISABLE
 
 // clang-format off
 // KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
@@ -2419,7 +2871,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_FAST_CHECK_UNARY_FALSE   DOCTEST_CHECK_UNARY_FALSE
 #define DOCTEST_FAST_REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INVOKE
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id,__VA_ARGS__)
 // clang-format on
 
 // BDD style macros
@@ -2437,175 +2889,156 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 // clang-format on
 
 // == SHORT VERSIONS OF THE MACROS
-#if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
+#ifndef DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
-#define TEST_CASE DOCTEST_TEST_CASE
-#define TEST_CASE_CLASS DOCTEST_TEST_CASE_CLASS
-#define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
-#define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
-#define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
-#define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
-#define TEST_CASE_TEMPLATE_INVOKE DOCTEST_TEST_CASE_TEMPLATE_INVOKE
-#define TEST_CASE_TEMPLATE_APPLY DOCTEST_TEST_CASE_TEMPLATE_APPLY
-#define SUBCASE DOCTEST_SUBCASE
-#define TEST_SUITE DOCTEST_TEST_SUITE
-#define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
+#define TEST_CASE(name) DOCTEST_TEST_CASE(name)
+#define TEST_CASE_CLASS(name) DOCTEST_TEST_CASE_CLASS(name)
+#define TEST_CASE_FIXTURE(x, name) DOCTEST_TEST_CASE_FIXTURE(x, name)
+#define TYPE_TO_STRING_AS(str, ...) DOCTEST_TYPE_TO_STRING_AS(str, __VA_ARGS__)
+#define TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING(__VA_ARGS__)
+#define TEST_CASE_TEMPLATE(name, T, ...) DOCTEST_TEST_CASE_TEMPLATE(name, T, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, T, id)
+#define TEST_CASE_TEMPLATE_INVOKE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_APPLY(id, ...) DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, __VA_ARGS__)
+#define SUBCASE(name) DOCTEST_SUBCASE(name)
+#define TEST_SUITE(decorators) DOCTEST_TEST_SUITE(decorators)
+#define TEST_SUITE_BEGIN(name) DOCTEST_TEST_SUITE_BEGIN(name)
 #define TEST_SUITE_END DOCTEST_TEST_SUITE_END
-#define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
-#define REGISTER_REPORTER DOCTEST_REGISTER_REPORTER
-#define REGISTER_LISTENER DOCTEST_REGISTER_LISTENER
-#define INFO DOCTEST_INFO
-#define CAPTURE DOCTEST_CAPTURE
-#define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
-#define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
-#define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
-#define MESSAGE DOCTEST_MESSAGE
-#define FAIL_CHECK DOCTEST_FAIL_CHECK
-#define FAIL DOCTEST_FAIL
-#define TO_LVALUE DOCTEST_TO_LVALUE
+#define REGISTER_EXCEPTION_TRANSLATOR(signature) DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)
+#define REGISTER_REPORTER(name, priority, reporter) DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define REGISTER_LISTENER(name, priority, reporter) DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+#define INFO(...) DOCTEST_INFO(__VA_ARGS__)
+#define CAPTURE(x) DOCTEST_CAPTURE(x)
+#define ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_MESSAGE_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_FAIL_CHECK_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_FAIL_AT(file, line, __VA_ARGS__)
+#define MESSAGE(...) DOCTEST_MESSAGE(__VA_ARGS__)
+#define FAIL_CHECK(...) DOCTEST_FAIL_CHECK(__VA_ARGS__)
+#define FAIL(...) DOCTEST_FAIL(__VA_ARGS__)
+#define TO_LVALUE(...) DOCTEST_TO_LVALUE(__VA_ARGS__)
 
-#define WARN DOCTEST_WARN
-#define WARN_FALSE DOCTEST_WARN_FALSE
-#define WARN_THROWS DOCTEST_WARN_THROWS
-#define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
-#define WARN_THROWS_WITH DOCTEST_WARN_THROWS_WITH
-#define WARN_THROWS_WITH_AS DOCTEST_WARN_THROWS_WITH_AS
-#define WARN_NOTHROW DOCTEST_WARN_NOTHROW
-#define CHECK DOCTEST_CHECK
-#define CHECK_FALSE DOCTEST_CHECK_FALSE
-#define CHECK_THROWS DOCTEST_CHECK_THROWS
-#define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
-#define CHECK_THROWS_WITH DOCTEST_CHECK_THROWS_WITH
-#define CHECK_THROWS_WITH_AS DOCTEST_CHECK_THROWS_WITH_AS
-#define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
-#define REQUIRE DOCTEST_REQUIRE
-#define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
-#define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
-#define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
-#define REQUIRE_THROWS_WITH DOCTEST_REQUIRE_THROWS_WITH
-#define REQUIRE_THROWS_WITH_AS DOCTEST_REQUIRE_THROWS_WITH_AS
-#define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
+#define WARN(...) DOCTEST_WARN(__VA_ARGS__)
+#define WARN_FALSE(...) DOCTEST_WARN_FALSE(__VA_ARGS__)
+#define WARN_THROWS(...) DOCTEST_WARN_THROWS(__VA_ARGS__)
+#define WARN_THROWS_AS(expr, ...) DOCTEST_WARN_THROWS_AS(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH(expr, ...) DOCTEST_WARN_THROWS_WITH(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_WARN_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define WARN_NOTHROW(...) DOCTEST_WARN_NOTHROW(__VA_ARGS__)
+#define CHECK(...) DOCTEST_CHECK(__VA_ARGS__)
+#define CHECK_FALSE(...) DOCTEST_CHECK_FALSE(__VA_ARGS__)
+#define CHECK_THROWS(...) DOCTEST_CHECK_THROWS(__VA_ARGS__)
+#define CHECK_THROWS_AS(expr, ...) DOCTEST_CHECK_THROWS_AS(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH(expr, ...) DOCTEST_CHECK_THROWS_WITH(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define CHECK_NOTHROW(...) DOCTEST_CHECK_NOTHROW(__VA_ARGS__)
+#define REQUIRE(...) DOCTEST_REQUIRE(__VA_ARGS__)
+#define REQUIRE_FALSE(...) DOCTEST_REQUIRE_FALSE(__VA_ARGS__)
+#define REQUIRE_THROWS(...) DOCTEST_REQUIRE_THROWS(__VA_ARGS__)
+#define REQUIRE_THROWS_AS(expr, ...) DOCTEST_REQUIRE_THROWS_AS(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH(expr, ...) DOCTEST_REQUIRE_THROWS_WITH(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
-#define WARN_MESSAGE DOCTEST_WARN_MESSAGE
-#define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
-#define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
-#define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
-#define WARN_THROWS_WITH_MESSAGE DOCTEST_WARN_THROWS_WITH_MESSAGE
-#define WARN_THROWS_WITH_AS_MESSAGE DOCTEST_WARN_THROWS_WITH_AS_MESSAGE
-#define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
-#define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
-#define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
-#define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
-#define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
-#define CHECK_THROWS_WITH_MESSAGE DOCTEST_CHECK_THROWS_WITH_MESSAGE
-#define CHECK_THROWS_WITH_AS_MESSAGE DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE
-#define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
-#define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
-#define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
-#define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
-#define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#define REQUIRE_THROWS_WITH_MESSAGE DOCTEST_REQUIRE_THROWS_WITH_MESSAGE
-#define REQUIRE_THROWS_WITH_AS_MESSAGE DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE
-#define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
+#define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_WARN_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_MESSAGE(cond, ...) DOCTEST_CHECK_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_CHECK_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_CHECK_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_MESSAGE(cond, ...) DOCTEST_REQUIRE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_REQUIRE_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_REQUIRE_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 
-#define SCENARIO DOCTEST_SCENARIO
-#define SCENARIO_CLASS DOCTEST_SCENARIO_CLASS
-#define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
-#define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
-#define GIVEN DOCTEST_GIVEN
-#define WHEN DOCTEST_WHEN
-#define AND_WHEN DOCTEST_AND_WHEN
-#define THEN DOCTEST_THEN
-#define AND_THEN DOCTEST_AND_THEN
+#define SCENARIO(name) DOCTEST_SCENARIO(name)
+#define SCENARIO_CLASS(name) DOCTEST_SCENARIO_CLASS(name)
+#define SCENARIO_TEMPLATE(name, T, ...) DOCTEST_SCENARIO_TEMPLATE(name, T, __VA_ARGS__)
+#define SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id)
+#define GIVEN(name) DOCTEST_GIVEN(name)
+#define WHEN(name) DOCTEST_WHEN(name)
+#define AND_WHEN(name) DOCTEST_AND_WHEN(name)
+#define THEN(name) DOCTEST_THEN(name)
+#define AND_THEN(name) DOCTEST_AND_THEN(name)
 
-#define WARN_EQ DOCTEST_WARN_EQ
-#define CHECK_EQ DOCTEST_CHECK_EQ
-#define REQUIRE_EQ DOCTEST_REQUIRE_EQ
-#define WARN_NE DOCTEST_WARN_NE
-#define CHECK_NE DOCTEST_CHECK_NE
-#define REQUIRE_NE DOCTEST_REQUIRE_NE
-#define WARN_GT DOCTEST_WARN_GT
-#define CHECK_GT DOCTEST_CHECK_GT
-#define REQUIRE_GT DOCTEST_REQUIRE_GT
-#define WARN_LT DOCTEST_WARN_LT
-#define CHECK_LT DOCTEST_CHECK_LT
-#define REQUIRE_LT DOCTEST_REQUIRE_LT
-#define WARN_GE DOCTEST_WARN_GE
-#define CHECK_GE DOCTEST_CHECK_GE
-#define REQUIRE_GE DOCTEST_REQUIRE_GE
-#define WARN_LE DOCTEST_WARN_LE
-#define CHECK_LE DOCTEST_CHECK_LE
-#define REQUIRE_LE DOCTEST_REQUIRE_LE
-#define WARN_UNARY DOCTEST_WARN_UNARY
-#define CHECK_UNARY DOCTEST_CHECK_UNARY
-#define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
-#define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
-#define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
-#define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
+#define WARN_EQ(...) DOCTEST_WARN_EQ(__VA_ARGS__)
+#define CHECK_EQ(...) DOCTEST_CHECK_EQ(__VA_ARGS__)
+#define REQUIRE_EQ(...) DOCTEST_REQUIRE_EQ(__VA_ARGS__)
+#define WARN_NE(...) DOCTEST_WARN_NE(__VA_ARGS__)
+#define CHECK_NE(...) DOCTEST_CHECK_NE(__VA_ARGS__)
+#define REQUIRE_NE(...) DOCTEST_REQUIRE_NE(__VA_ARGS__)
+#define WARN_GT(...) DOCTEST_WARN_GT(__VA_ARGS__)
+#define CHECK_GT(...) DOCTEST_CHECK_GT(__VA_ARGS__)
+#define REQUIRE_GT(...) DOCTEST_REQUIRE_GT(__VA_ARGS__)
+#define WARN_LT(...) DOCTEST_WARN_LT(__VA_ARGS__)
+#define CHECK_LT(...) DOCTEST_CHECK_LT(__VA_ARGS__)
+#define REQUIRE_LT(...) DOCTEST_REQUIRE_LT(__VA_ARGS__)
+#define WARN_GE(...) DOCTEST_WARN_GE(__VA_ARGS__)
+#define CHECK_GE(...) DOCTEST_CHECK_GE(__VA_ARGS__)
+#define REQUIRE_GE(...) DOCTEST_REQUIRE_GE(__VA_ARGS__)
+#define WARN_LE(...) DOCTEST_WARN_LE(__VA_ARGS__)
+#define CHECK_LE(...) DOCTEST_CHECK_LE(__VA_ARGS__)
+#define REQUIRE_LE(...) DOCTEST_REQUIRE_LE(__VA_ARGS__)
+#define WARN_UNARY(...) DOCTEST_WARN_UNARY(__VA_ARGS__)
+#define CHECK_UNARY(...) DOCTEST_CHECK_UNARY(__VA_ARGS__)
+#define REQUIRE_UNARY(...) DOCTEST_REQUIRE_UNARY(__VA_ARGS__)
+#define WARN_UNARY_FALSE(...) DOCTEST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define CHECK_UNARY_FALSE(...) DOCTEST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define REQUIRE_UNARY_FALSE(...) DOCTEST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
 // KEPT FOR BACKWARDS COMPATIBILITY
-#define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
-#define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
-#define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
-#define FAST_WARN_NE DOCTEST_FAST_WARN_NE
-#define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
-#define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
-#define FAST_WARN_GT DOCTEST_FAST_WARN_GT
-#define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
-#define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
-#define FAST_WARN_LT DOCTEST_FAST_WARN_LT
-#define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
-#define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
-#define FAST_WARN_GE DOCTEST_FAST_WARN_GE
-#define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
-#define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
-#define FAST_WARN_LE DOCTEST_FAST_WARN_LE
-#define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
-#define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
+#define FAST_WARN_EQ(...) DOCTEST_FAST_WARN_EQ(__VA_ARGS__)
+#define FAST_CHECK_EQ(...) DOCTEST_FAST_CHECK_EQ(__VA_ARGS__)
+#define FAST_REQUIRE_EQ(...) DOCTEST_FAST_REQUIRE_EQ(__VA_ARGS__)
+#define FAST_WARN_NE(...) DOCTEST_FAST_WARN_NE(__VA_ARGS__)
+#define FAST_CHECK_NE(...) DOCTEST_FAST_CHECK_NE(__VA_ARGS__)
+#define FAST_REQUIRE_NE(...) DOCTEST_FAST_REQUIRE_NE(__VA_ARGS__)
+#define FAST_WARN_GT(...) DOCTEST_FAST_WARN_GT(__VA_ARGS__)
+#define FAST_CHECK_GT(...) DOCTEST_FAST_CHECK_GT(__VA_ARGS__)
+#define FAST_REQUIRE_GT(...) DOCTEST_FAST_REQUIRE_GT(__VA_ARGS__)
+#define FAST_WARN_LT(...) DOCTEST_FAST_WARN_LT(__VA_ARGS__)
+#define FAST_CHECK_LT(...) DOCTEST_FAST_CHECK_LT(__VA_ARGS__)
+#define FAST_REQUIRE_LT(...) DOCTEST_FAST_REQUIRE_LT(__VA_ARGS__)
+#define FAST_WARN_GE(...) DOCTEST_FAST_WARN_GE(__VA_ARGS__)
+#define FAST_CHECK_GE(...) DOCTEST_FAST_CHECK_GE(__VA_ARGS__)
+#define FAST_REQUIRE_GE(...) DOCTEST_FAST_REQUIRE_GE(__VA_ARGS__)
+#define FAST_WARN_LE(...) DOCTEST_FAST_WARN_LE(__VA_ARGS__)
+#define FAST_CHECK_LE(...) DOCTEST_FAST_CHECK_LE(__VA_ARGS__)
+#define FAST_REQUIRE_LE(...) DOCTEST_FAST_REQUIRE_LE(__VA_ARGS__)
 
-#define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
-#define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
-#define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
-#define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
-#define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
-#define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#define FAST_WARN_UNARY(...) DOCTEST_FAST_WARN_UNARY(__VA_ARGS__)
+#define FAST_CHECK_UNARY(...) DOCTEST_FAST_CHECK_UNARY(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY(...) DOCTEST_FAST_REQUIRE_UNARY(__VA_ARGS__)
+#define FAST_WARN_UNARY_FALSE(...) DOCTEST_FAST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define FAST_CHECK_UNARY_FALSE(...) DOCTEST_FAST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY_FALSE(...) DOCTEST_FAST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
-#define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
+#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
-#if !defined(DOCTEST_CONFIG_DISABLE)
+#ifndef DOCTEST_CONFIG_DISABLE
 
 // this is here to clear the 'current test suite' for the current translation unit - at the top
 DOCTEST_TEST_SUITE_END();
-
-// add stringification for primitive/fundamental types
-namespace doctest { namespace detail {
-    DOCTEST_TYPE_TO_STRING_IMPL(bool)
-    DOCTEST_TYPE_TO_STRING_IMPL(float)
-    DOCTEST_TYPE_TO_STRING_IMPL(double)
-    DOCTEST_TYPE_TO_STRING_IMPL(long double)
-    DOCTEST_TYPE_TO_STRING_IMPL(char)
-    DOCTEST_TYPE_TO_STRING_IMPL(signed char)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
-#if !DOCTEST_MSVC || defined(_NATIVE_WCHAR_T_DEFINED)
-    DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
-#endif // not MSVC or wchar_t support enabled
-    DOCTEST_TYPE_TO_STRING_IMPL(short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
-    DOCTEST_TYPE_TO_STRING_IMPL(long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(long long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
-}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
 #endif // DOCTEST_LIBRARY_INCLUDED
 
@@ -2626,13 +3059,11 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-macros")
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
+DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH
+
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")
@@ -2640,64 +3071,35 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-local-typedef")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
-DOCTEST_GCC_SUPPRESS_WARNING("-Winline")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
 DOCTEST_MSVC_SUPPRESS_WARNING(4267) // 'var' : conversion from 'x' to 'y', possible loss of data
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
 DOCTEST_MSVC_SUPPRESS_WARNING(4530) // C++ exception handler used, but unwind semantics not enabled
 DOCTEST_MSVC_SUPPRESS_WARNING(4577) // 'noexcept' used with no exception handling mode specified
 DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument is not a string literal
 DOCTEST_MSVC_SUPPRESS_WARNING(4365) // conversion from 'int' to 'unsigned', signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding in structs
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
 DOCTEST_MSVC_SUPPRESS_WARNING(5039) // pointer to potentially throwing function passed to extern C
-DOCTEST_MSVC_SUPPRESS_WARNING(5045) // Spectre mitigation stuff
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
-// static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtor...
+DOCTEST_MSVC_SUPPRESS_WARNING(5245) // unreferenced function with internal linkage has been removed
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
@@ -2705,7 +3107,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <ctime>
 #include <cmath>
 #include <climits>
-// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/onqtam/doctest/pull/37
+// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/doctest/doctest/pull/37
 #ifdef __BORLANDC__
 #include <math.h>
 #endif // __BORLANDC__
@@ -2721,18 +3123,27 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <algorithm>
 #include <iomanip>
 #include <vector>
+#ifndef DOCTEST_CONFIG_NO_MULTITHREADING
 #include <atomic>
 #include <mutex>
+#define DOCTEST_DECLARE_MUTEX(name) std::mutex name;
+#define DOCTEST_DECLARE_STATIC_MUTEX(name) static DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name) std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
+#else // DOCTEST_CONFIG_NO_MULTITHREADING
+#define DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_DECLARE_STATIC_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name)
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
 #include <set>
 #include <map>
+#include <unordered_set>
 #include <exception>
 #include <stdexcept>
-#ifdef DOCTEST_CONFIG_POSIX_SIGNALS
 #include <csignal>
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS
 #include <cfloat>
 #include <cctype>
 #include <cstdint>
+#include <string>
 
 #ifdef DOCTEST_PLATFORM_MAC
 #include <sys/types.h>
@@ -2754,7 +3165,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #include <io.h>
 
@@ -2764,6 +3175,12 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <unistd.h>
 
 #endif // DOCTEST_PLATFORM_WINDOWS
+
+// this is a fix for https://github.com/doctest/doctest/issues/348
+// https://mail.gnome.org/archives/xml/2012-January/msg00000.html
+#if !defined(HAVE_UNISTD_H) && !defined(STDOUT_FILENO)
+#define STDOUT_FILENO fileno(stdout)
+#endif // HAVE_UNISTD_H
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
@@ -2781,7 +3198,19 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif
 
 #ifndef DOCTEST_THREAD_LOCAL
+#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_THREAD_LOCAL
+#else // DOCTEST_MSVC
 #define DOCTEST_THREAD_LOCAL thread_local
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_THREAD_LOCAL
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES
+#define DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES 32
+#endif
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE
+#define DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE 64
 #endif
 
 #ifdef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -2790,555 +3219,719 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_OPTIONS_PREFIX_DISPLAY ""
 #endif
 
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+#endif
+
+#ifndef DOCTEST_CDECL
+#define DOCTEST_CDECL __cdecl
+#endif
+
 namespace doctest {
 
 bool is_running_in_test = false;
 
 namespace {
-    using namespace detail;
-    // case insensitive strcmp
-    int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
-            const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
-        }
-    }
+using namespace detail;
 
-    template <typename T>
-    String fpToString(T value, int precision) {
-        std::ostringstream oss;
-        oss << std::setprecision(precision) << std::fixed << value;
-        std::string d = oss.str();
-        size_t      i = d.find_last_not_of('0');
-        if(i != std::string::npos && i != d.size() - 1) {
-            if(d[i] == '.')
-                i++;
-            d = d.substr(0, i + 1);
-        }
-        return d.c_str();
-    }
+template <typename Ex>
+DOCTEST_NORETURN void throw_exception(Ex const& e) {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+  throw e;
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+  std::cerr << "doctest will terminate because it needed to throw an exception.\n"
+            << "The message was: " << e.what() << '\n';
+  std::terminate();
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+}
 
-    struct Endianness
-    {
-        enum Arch
-        {
-            Big,
-            Little
-        };
+#ifndef DOCTEST_INTERNAL_ERROR
+#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
+    throw_exception(std::logic_error(                                                              \
+            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
+#endif // DOCTEST_INTERNAL_ERROR
 
-        static Arch which() {
-            int x = 1;
-            // casting any data pointer to char* is allowed
-            auto ptr = reinterpret_cast<char*>(&x);
-            if(*ptr)
-                return Little;
-            return Big;
-        }
-    };
+// case insensitive strcmp
+int stricmp(const char* a, const char* b) {
+  for(;; a++, b++) {
+    const int d = tolower(*a) - tolower(*b);
+    if(d != 0 || !*a)
+      return d;
+  }
+}
+
+struct Endianness
+{
+  enum Arch
+  {
+    Big,
+    Little
+  };
+
+  static Arch which() {
+    int x = 1;
+    // casting any data pointer to char* is allowed
+    auto ptr = reinterpret_cast<char*>(&x);
+    if(*ptr)
+      return Little;
+    return Big;
+  }
+};
 } // namespace
 
 namespace detail {
-    void my_memcpy(void* dest, const void* src, unsigned num) { memcpy(dest, src, num); }
+DOCTEST_THREAD_LOCAL class
+{
+  std::vector<std::streampos> stack;
+  std::stringstream           ss;
 
-    String rawMemoryToString(const void* object, unsigned size) {
-        // Reverse order for little endian architectures
-        int i = 0, end = static_cast<int>(size), inc = 1;
-        if(Endianness::which() == Endianness::Little) {
-            i   = end - 1;
-            end = inc = -1;
-        }
+public:
+  std::ostream* push() {
+    stack.push_back(ss.tellp());
+    return &ss;
+  }
 
-        unsigned const char* bytes = static_cast<unsigned const char*>(object);
-        std::ostringstream   oss;
-        oss << "0x" << std::setfill('0') << std::hex;
-        for(; i != end; i += inc)
-            oss << std::setw(2) << static_cast<unsigned>(bytes[i]);
-        return oss.str().c_str();
-    }
+  String pop() {
+    if (stack.empty())
+      DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
 
-    DOCTEST_THREAD_LOCAL std::ostringstream g_oss; // NOLINT(cert-err58-cpp)
+    std::streampos pos = stack.back();
+    stack.pop_back();
+    unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
+    ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
+    return String(ss, sz);
+  }
+} g_oss;
 
-    std::ostream* getTlsOss() {
-        g_oss.clear(); // there shouldn't be anything worth clearing in the flags
-        g_oss.str(""); // the slow way of resetting a string stream
-        //g_oss.seekp(0); // optimal reset - as seen here: https://stackoverflow.com/a/624291/3162383
-        return &g_oss;
-    }
+std::ostream* tlssPush() {
+  return g_oss.push();
+}
 
-    String getTlsOssResult() {
-        //g_oss << std::ends; // needed - as shown here: https://stackoverflow.com/a/624291/3162383
-        return g_oss.str().c_str();
-    }
+String tlssPop() {
+  return g_oss.pop();
+}
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-    typedef uint64_t UInt64;
+namespace timer_large_integer
+{
+
+#if defined(DOCTEST_PLATFORM_WINDOWS)
+using type = ULONGLONG;
+#else // DOCTEST_PLATFORM_WINDOWS
+using type = std::uint64_t;
+#endif // DOCTEST_PLATFORM_WINDOWS
+}
+
+using ticks_t = timer_large_integer::type;
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
-    UInt64 getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
+ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
-    UInt64 getCurrentTicks() {
-        static UInt64 hz = 0, hzo = 0;
-        if(!hz) {
-            QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&hz));
-            QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&hzo));
-        }
-        UInt64 t;
-        QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&t));
-        return ((t - hzo) * 1000000) / hz;
-    }
+ticks_t getCurrentTicks() {
+  static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
+  if(!hz.QuadPart) {
+    QueryPerformanceFrequency(&hz);
+    QueryPerformanceCounter(&hzo);
+  }
+  LARGE_INTEGER t;
+  QueryPerformanceCounter(&t);
+  return ((t.QuadPart - hzo.QuadPart) * LONGLONG(1000000)) / hz.QuadPart;
+}
 #else  // DOCTEST_PLATFORM_WINDOWS
-    UInt64 getCurrentTicks() {
-        timeval t;
-        gettimeofday(&t, nullptr);
-        return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
-    }
+ticks_t getCurrentTicks() {
+  timeval t;
+  gettimeofday(&t, nullptr);
+  return static_cast<ticks_t>(t.tv_sec) * 1000000 + static_cast<ticks_t>(t.tv_usec);
+}
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-    struct Timer
-    {
-        void         start() { m_ticks = getCurrentTicks(); }
-        unsigned int getElapsedMicroseconds() const {
-            return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
-        }
-        //unsigned int getElapsedMilliseconds() const {
-        //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
-        //}
-        double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
+struct Timer
+{
+  void         start() { m_ticks = getCurrentTicks(); }
+  unsigned int getElapsedMicroseconds() const {
+    return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
+  }
+  //unsigned int getElapsedMilliseconds() const {
+  //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
+  //}
+  double getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
 
-    private:
-        UInt64 m_ticks = 0;
-    };
+private:
+  ticks_t m_ticks = 0;
+};
 
-    // this holds both parameters from the command line and runtime data for tests
-    struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
-    {
-        std::atomic<int> numAssertsCurrentTest_atomic;
-        std::atomic<int> numAssertsFailedCurrentTest_atomic;
+#ifdef DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = T;
+#else // DOCTEST_CONFIG_NO_MULTITHREADING
+template <typename T>
+using Atomic = std::atomic<T>;
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
 
-        std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
+#if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
+template <typename T>
+using MultiLaneAtomic = Atomic<T>;
+#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+// Provides a multilane implementation of an atomic variable that supports add, sub, load,
+// store. Instead of using a single atomic variable, this splits up into multiple ones,
+// each sitting on a separate cache line. The goal is to provide a speedup when most
+// operations are modifying. It achieves this with two properties:
+//
+// * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
+// * Each atomic sits on a separate cache line, so false sharing is reduced.
+//
+// The disadvantage is that there is a small overhead due to the use of TLS, and load/store
+// is slower because all atomics have to be accessed.
+template <typename T>
+class MultiLaneAtomic
+{
+  struct CacheLineAlignedAtomic
+  {
+    Atomic<T> atomic{};
+    char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
+  };
+  CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
 
-        std::vector<IReporter*> reporters_currently_used;
+  static_assert(sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
+                "guarantee one atomic takes exactly one cache line");
 
-        const TestCase* currentTest = nullptr;
+public:
+  T operator++() DOCTEST_NOEXCEPT { return fetch_add(1) + 1; }
 
-        assert_handler ah = nullptr;
+  T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
 
-        Timer timer;
+  T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+    return myAtomic().fetch_add(arg, order);
+  }
 
-        std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+  T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+    return myAtomic().fetch_sub(arg, order);
+  }
 
-        // stuff for subcases
-        std::vector<SubcaseSignature>     subcasesStack;
-        std::set<decltype(subcasesStack)> subcasesPassed;
-        int                               subcasesCurrentMaxLevel;
-        bool                              should_reenter;
-        std::atomic<bool>                 shouldLogCurrentException;
+  operator T() const DOCTEST_NOEXCEPT { return load(); }
 
-        void resetRunData() {
-            numTestCases                = 0;
-            numTestCasesPassingFilters  = 0;
-            numTestSuitesPassingFilters = 0;
-            numTestCasesFailed          = 0;
-            numAsserts                  = 0;
-            numAssertsFailed            = 0;
-            numAssertsCurrentTest       = 0;
-            numAssertsFailedCurrentTest = 0;
-        }
+  T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+    auto result = T();
+    for(auto const& c : m_atomics) {
+      result += c.atomic.load(order);
+    }
+    return result;
+  }
 
-        void finalizeTestCaseData() {
-            seconds = timer.getElapsedSeconds();
+  T operator=(T desired) DOCTEST_NOEXCEPT { // lgtm [cpp/assignment-does-not-return-this]
+    store(desired);
+    return desired;
+  }
 
-            // update the non-atomic counters
-            numAsserts += numAssertsCurrentTest_atomic;
-            numAssertsFailed += numAssertsFailedCurrentTest_atomic;
-            numAssertsCurrentTest       = numAssertsCurrentTest_atomic;
-            numAssertsFailedCurrentTest = numAssertsFailedCurrentTest_atomic;
+  void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+    // first value becomes desired", all others become 0.
+    for(auto& c : m_atomics) {
+      c.atomic.store(desired, order);
+      desired = {};
+    }
+  }
 
-            if(numAssertsFailedCurrentTest)
-                failure_flags |= TestCaseFailureReason::AssertFailure;
+private:
+  // Each thread has a different atomic that it operates on. If more than NumLanes threads
+  // use this, some will use the same atomic. So performance will degrade a bit, but still
+  // everything will work.
+  //
+  // The logic here is a bit tricky. The call should be as fast as possible, so that there
+  // is minimal to no overhead in determining the correct atomic for the current thread.
+  //
+  // 1. A global static counter laneCounter counts continuously up.
+  // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
+  //    assigned in a round-robin fashion.
+  // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
+  //    little overhead.
+  Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
+    static Atomic<size_t> laneCounter;
+    DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
+        laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
 
-            if(Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
-               Approx(seconds).epsilon(DBL_EPSILON) > currentTest->m_timeout)
-                failure_flags |= TestCaseFailureReason::Timeout;
+    return m_atomics[tlsLaneIdx].atomic;
+  }
+};
+#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
-            if(currentTest->m_should_fail) {
-                if(failure_flags) {
-                    failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
-                } else {
-                    failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
-                }
-            } else if(failure_flags && currentTest->m_may_fail) {
-                failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
-            } else if(currentTest->m_expected_failures > 0) {
-                if(numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
-                    failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
-                } else {
-                    failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
-                }
-            }
+// this holds both parameters from the command line and runtime data for tests
+struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
+{
+  MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
+  MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
-            bool ok_to_fail = (TestCaseFailureReason::ShouldHaveFailedAndDid & failure_flags) ||
-                              (TestCaseFailureReason::CouldHaveFailedAndDid & failure_flags) ||
-                              (TestCaseFailureReason::FailedExactlyNumTimes & failure_flags);
+  std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
 
-            // if any subcase has failed - the whole test case has failed
-            if(failure_flags && !ok_to_fail)
-                numTestCasesFailed++;
-        }
-    };
+  std::vector<IReporter*> reporters_currently_used;
 
-    ContextState* g_cs = nullptr;
+  assert_handler ah = nullptr;
 
-    // used to avoid locks for the debug output
-    // TODO: figure out if this is indeed necessary/correct - seems like either there still
-    // could be a race or that there wouldn't be a race even if using the context directly
-    DOCTEST_THREAD_LOCAL bool g_no_colors;
+  Timer timer;
+
+  std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+
+  // stuff for subcases
+  bool reachedLeaf;
+  std::vector<SubcaseSignature> subcaseStack;
+  std::vector<SubcaseSignature> nextSubcaseStack;
+  std::unordered_set<unsigned long long> fullyTraversedSubcases;
+  size_t currentSubcaseDepth;
+  Atomic<bool> shouldLogCurrentException;
+
+  void resetRunData() {
+    numTestCases                = 0;
+    numTestCasesPassingFilters  = 0;
+    numTestSuitesPassingFilters = 0;
+    numTestCasesFailed          = 0;
+    numAsserts                  = 0;
+    numAssertsFailed            = 0;
+    numAssertsCurrentTest       = 0;
+    numAssertsFailedCurrentTest = 0;
+  }
+
+  void finalizeTestCaseData() {
+    seconds = timer.getElapsedSeconds();
+
+    // update the non-atomic counters
+    numAsserts += numAssertsCurrentTest_atomic;
+    numAssertsFailed += numAssertsFailedCurrentTest_atomic;
+    numAssertsCurrentTest       = numAssertsCurrentTest_atomic;
+    numAssertsFailedCurrentTest = numAssertsFailedCurrentTest_atomic;
+
+    if(numAssertsFailedCurrentTest)
+      failure_flags |= TestCaseFailureReason::AssertFailure;
+
+    if(Approx(currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+        Approx(seconds).epsilon(DBL_EPSILON) > currentTest->m_timeout)
+      failure_flags |= TestCaseFailureReason::Timeout;
+
+    if(currentTest->m_should_fail) {
+      if(failure_flags) {
+        failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
+      } else {
+        failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
+      }
+    } else if(failure_flags && currentTest->m_may_fail) {
+      failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
+    } else if(currentTest->m_expected_failures > 0) {
+      if(numAssertsFailedCurrentTest == currentTest->m_expected_failures) {
+        failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
+      } else {
+        failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
+      }
+    }
+
+    bool ok_to_fail = (TestCaseFailureReason::ShouldHaveFailedAndDid & failure_flags) ||
+                      (TestCaseFailureReason::CouldHaveFailedAndDid & failure_flags) ||
+                      (TestCaseFailureReason::FailedExactlyNumTimes & failure_flags);
+
+    // if any subcase has failed - the whole test case has failed
+    testCaseSuccess = !(failure_flags && !ok_to_fail);
+    if(!testCaseSuccess)
+      numTestCasesFailed++;
+  }
+};
+
+ContextState* g_cs = nullptr;
+
+// used to avoid locks for the debug output
+// TODO: figure out if this is indeed necessary/correct - seems like either there still
+// could be a race or that there wouldn't be a race even if using the context directly
+DOCTEST_THREAD_LOCAL bool g_no_colors;
 
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace detail
 
-void String::setOnHeap() { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-void String::setLast(unsigned in) { buf[last] = char(in); }
-
-void String::copy(const String& other) {
-    if(other.isOnStack()) {
-        memcpy(buf, other.buf, len);
-    } else {
-        setOnHeap();
-        data.size     = other.data.size;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        memcpy(data.ptr, other.data.ptr, data.size + 1);
-    }
+char* String::allocate(size_type sz) {
+  if (sz <= last) {
+    buf[sz] = '\0';
+    setLast(last - sz);
+    return buf;
+  } else {
+    setOnHeap();
+    data.size = sz;
+    data.capacity = data.size + 1;
+    data.ptr = new char[data.capacity];
+    data.ptr[sz] = '\0';
+    return data.ptr;
+  }
 }
 
-String::String() {
-    buf[0] = '\0';
-    setLast();
+void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
+void String::setLast(size_type in) noexcept { buf[last] = char(in); }
+void String::setSize(size_type sz) noexcept {
+  if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
+  else { data.ptr[sz] = '\0'; data.size = sz; }
+}
+
+void String::copy(const String& other) {
+  if(other.isOnStack()) {
+    memcpy(buf, other.buf, len);
+  } else {
+    memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
+  }
+}
+
+String::String() noexcept {
+  buf[0] = '\0';
+  setLast();
 }
 
 String::~String() {
-    if(!isOnStack())
-        delete[] data.ptr;
-}
+  if(!isOnStack())
+    delete[] data.ptr;
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 String::String(const char* in)
-        : String(in, strlen(in)) {}
+    : String(in, strlen(in)) {}
 
-String::String(const char* in, unsigned in_size) {
-    if(in_size <= last) {
-        memcpy(buf, in, in_size + 1);
-        setLast(last - in_size);
-    } else {
-        setOnHeap();
-        data.size     = in_size;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        memcpy(data.ptr, in, in_size + 1);
-    }
+String::String(const char* in, size_type in_size) {
+  memcpy(allocate(in_size), in, in_size);
+}
+
+String::String(std::istream& in, size_type in_size) {
+  in.read(allocate(in_size), in_size);
 }
 
 String::String(const String& other) { copy(other); }
 
 String& String::operator=(const String& other) {
-    if(this != &other) {
-        if(!isOnStack())
-            delete[] data.ptr;
+  if(this != &other) {
+    if(!isOnStack())
+      delete[] data.ptr;
 
-        copy(other);
-    }
+    copy(other);
+  }
 
-    return *this;
+  return *this;
 }
 
 String& String::operator+=(const String& other) {
-    const unsigned my_old_size = size();
-    const unsigned other_size  = other.size();
-    const unsigned total_size  = my_old_size + other_size;
-    if(isOnStack()) {
-        if(total_size < len) {
-            // append to the current stack space
-            memcpy(buf + my_old_size, other.c_str(), other_size + 1);
-            setLast(last - total_size);
-        } else {
-            // alloc new chunk
-            char* temp = new char[total_size + 1];
-            // copy current data to new location before writing in the union
-            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
-            // update data in union
-            setOnHeap();
-            data.size     = total_size;
-            data.capacity = data.size + 1;
-            data.ptr      = temp;
-            // transfer the rest of the data
-            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        }
+  const size_type my_old_size = size();
+  const size_type other_size  = other.size();
+  const size_type total_size  = my_old_size + other_size;
+  if(isOnStack()) {
+    if(total_size < len) {
+      // append to the current stack space
+      memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+      setLast(last - total_size);
     } else {
-        if(data.capacity > total_size) {
-            // append to the current heap block
-            data.size = total_size;
-            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        } else {
-            // resize
-            data.capacity *= 2;
-            if(data.capacity <= total_size)
-                data.capacity = total_size + 1;
-            // alloc new chunk
-            char* temp = new char[data.capacity];
-            // copy current data to new location before releasing it
-            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
-            // release old chunk
-            delete[] data.ptr;
-            // update the rest of the union members
-            data.size = total_size;
-            data.ptr  = temp;
-            // transfer the rest of the data
-            memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        }
+      // alloc new chunk
+      char* temp = new char[total_size + 1];
+      // copy current data to new location before writing in the union
+      memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+      // update data in union
+      setOnHeap();
+      data.size     = total_size;
+      data.capacity = data.size + 1;
+      data.ptr      = temp;
+      // transfer the rest of the data
+      memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
     }
+  } else {
+    if(data.capacity > total_size) {
+      // append to the current heap block
+      data.size = total_size;
+      memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+    } else {
+      // resize
+      data.capacity *= 2;
+      if(data.capacity <= total_size)
+        data.capacity = total_size + 1;
+      // alloc new chunk
+      char* temp = new char[data.capacity];
+      // copy current data to new location before releasing it
+      memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+      // release old chunk
+      delete[] data.ptr;
+      // update the rest of the union members
+      data.size = total_size;
+      data.ptr  = temp;
+      // transfer the rest of the data
+      memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
+    }
+  }
 
-    return *this;
+  return *this;
 }
 
-String String::operator+(const String& other) const { return String(*this) += other; }
+String::String(String&& other) noexcept {
+  memcpy(buf, other.buf, len);
+  other.buf[0] = '\0';
+  other.setLast();
+}
 
-String::String(String&& other) {
+String& String::operator=(String&& other) noexcept {
+  if(this != &other) {
+    if(!isOnStack())
+      delete[] data.ptr;
     memcpy(buf, other.buf, len);
     other.buf[0] = '\0';
     other.setLast();
+  }
+  return *this;
 }
 
-String& String::operator=(String&& other) {
-    if(this != &other) {
-        if(!isOnStack())
-            delete[] data.ptr;
-        memcpy(buf, other.buf, len);
-        other.buf[0] = '\0';
-        other.setLast();
-    }
-    return *this;
+char String::operator[](size_type i) const {
+  return const_cast<String*>(this)->operator[](i);
 }
 
-char String::operator[](unsigned i) const {
-    return const_cast<String*>(this)->operator[](i); // NOLINT
-}
-
-char& String::operator[](unsigned i) {
-    if(isOnStack())
-        return reinterpret_cast<char*>(buf)[i];
-    return data.ptr[i];
+char& String::operator[](size_type i) {
+  if(isOnStack())
+    return reinterpret_cast<char*>(buf)[i];
+  return data.ptr[i];
 }
 
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-unsigned String::size() const {
-    if(isOnStack())
-        return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
-    return data.size;
+String::size_type String::size() const {
+  if(isOnStack())
+    return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
+  return data.size;
 }
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-unsigned String::capacity() const {
-    if(isOnStack())
-        return len;
-    return data.capacity;
+String::size_type String::capacity() const {
+  if(isOnStack())
+    return len;
+  return data.capacity;
+}
+
+String String::substr(size_type pos, size_type cnt) && {
+  cnt = std::min(cnt, size() - 1 - pos);
+  char* cptr = c_str();
+  memmove(cptr, cptr + pos, cnt);
+  setSize(cnt);
+  return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const & {
+  cnt = std::min(cnt, size() - 1 - pos);
+  return String{ c_str() + pos, cnt };
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+  const char* begin = c_str();
+  const char* end = begin + size();
+  const char* it = begin + pos;
+  for (; it < end && *it != ch; it++);
+  if (it < end) { return static_cast<size_type>(it - begin); }
+  else { return npos; }
+}
+
+String::size_type String::rfind(char ch, size_type pos) const {
+  const char* begin = c_str();
+  const char* it = begin + std::min(pos, size() - 1);
+  for (; it >= begin && *it != ch; it--);
+  if (it >= begin) { return static_cast<size_type>(it - begin); }
+  else { return npos; }
 }
 
 int String::compare(const char* other, bool no_case) const {
-    if(no_case)
-        return stricmp(c_str(), other);
-    return std::strcmp(c_str(), other);
+  if(no_case)
+    return doctest::stricmp(c_str(), other);
+  return std::strcmp(c_str(), other);
 }
 
 int String::compare(const String& other, bool no_case) const {
-    return compare(other.c_str(), no_case);
+  return compare(other.c_str(), no_case);
 }
 
-// clang-format off
+String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
+
 bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
 bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
 bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
 bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
 bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
 bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-// clang-format on
 
 std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
 
+Contains::Contains(const String& str) : string(str) { }
+
+bool Contains::checkWith(const String& other) const {
+  return strstr(other.c_str(), string.c_str()) != nullptr;
+}
+
+String toString(const Contains& in) {
+  return "Contains( " + in.string + " )";
+}
+
+bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
+bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
+bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
+bool operator!=(const Contains& lhs, const String& rhs) { return !lhs.checkWith(rhs); }
+
 namespace {
-    void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
+void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
 } // namespace
 
 namespace Color {
-    std::ostream& operator<<(std::ostream& s, Color::Enum code) {
-        color_to_stream(s, code);
-        return s;
-    }
+std::ostream& operator<<(std::ostream& s, Color::Enum code) {
+  color_to_stream(s, code);
+  return s;
+}
 } // namespace Color
 
 // clang-format off
 const char* assertString(assertType::Enum at) {
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4062) // enum 'x' in switch of enum 'y' is not handled
-    switch(at) {  //!OCLINT missing default in switch statements
-        case assertType::DT_WARN                    : return "WARN";
-        case assertType::DT_CHECK                   : return "CHECK";
-        case assertType::DT_REQUIRE                 : return "REQUIRE";
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitely handled
+    #define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type) case assertType::DT_ ## assert_type: return #assert_type
+    #define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type) \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_ ## assert_type); \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_ ## assert_type); \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_ ## assert_type)
+    switch(at) {
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE);
 
-        case assertType::DT_WARN_FALSE              : return "WARN_FALSE";
-        case assertType::DT_CHECK_FALSE             : return "CHECK_FALSE";
-        case assertType::DT_REQUIRE_FALSE           : return "REQUIRE_FALSE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(FALSE);
 
-        case assertType::DT_WARN_THROWS             : return "WARN_THROWS";
-        case assertType::DT_CHECK_THROWS            : return "CHECK_THROWS";
-        case assertType::DT_REQUIRE_THROWS          : return "REQUIRE_THROWS";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS);
 
-        case assertType::DT_WARN_THROWS_AS          : return "WARN_THROWS_AS";
-        case assertType::DT_CHECK_THROWS_AS         : return "CHECK_THROWS_AS";
-        case assertType::DT_REQUIRE_THROWS_AS       : return "REQUIRE_THROWS_AS";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_AS);
 
-        case assertType::DT_WARN_THROWS_WITH        : return "WARN_THROWS_WITH";
-        case assertType::DT_CHECK_THROWS_WITH       : return "CHECK_THROWS_WITH";
-        case assertType::DT_REQUIRE_THROWS_WITH     : return "REQUIRE_THROWS_WITH";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH);
 
-        case assertType::DT_WARN_THROWS_WITH_AS     : return "WARN_THROWS_WITH_AS";
-        case assertType::DT_CHECK_THROWS_WITH_AS    : return "CHECK_THROWS_WITH_AS";
-        case assertType::DT_REQUIRE_THROWS_WITH_AS  : return "REQUIRE_THROWS_WITH_AS";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH_AS);
 
-        case assertType::DT_WARN_NOTHROW            : return "WARN_NOTHROW";
-        case assertType::DT_CHECK_NOTHROW           : return "CHECK_NOTHROW";
-        case assertType::DT_REQUIRE_NOTHROW         : return "REQUIRE_NOTHROW";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NOTHROW);
 
-        case assertType::DT_WARN_EQ                 : return "WARN_EQ";
-        case assertType::DT_CHECK_EQ                : return "CHECK_EQ";
-        case assertType::DT_REQUIRE_EQ              : return "REQUIRE_EQ";
-        case assertType::DT_WARN_NE                 : return "WARN_NE";
-        case assertType::DT_CHECK_NE                : return "CHECK_NE";
-        case assertType::DT_REQUIRE_NE              : return "REQUIRE_NE";
-        case assertType::DT_WARN_GT                 : return "WARN_GT";
-        case assertType::DT_CHECK_GT                : return "CHECK_GT";
-        case assertType::DT_REQUIRE_GT              : return "REQUIRE_GT";
-        case assertType::DT_WARN_LT                 : return "WARN_LT";
-        case assertType::DT_CHECK_LT                : return "CHECK_LT";
-        case assertType::DT_REQUIRE_LT              : return "REQUIRE_LT";
-        case assertType::DT_WARN_GE                 : return "WARN_GE";
-        case assertType::DT_CHECK_GE                : return "CHECK_GE";
-        case assertType::DT_REQUIRE_GE              : return "REQUIRE_GE";
-        case assertType::DT_WARN_LE                 : return "WARN_LE";
-        case assertType::DT_CHECK_LE                : return "CHECK_LE";
-        case assertType::DT_REQUIRE_LE              : return "REQUIRE_LE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(EQ);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LE);
 
-        case assertType::DT_WARN_UNARY              : return "WARN_UNARY";
-        case assertType::DT_CHECK_UNARY             : return "CHECK_UNARY";
-        case assertType::DT_REQUIRE_UNARY           : return "REQUIRE_UNARY";
-        case assertType::DT_WARN_UNARY_FALSE        : return "WARN_UNARY_FALSE";
-        case assertType::DT_CHECK_UNARY_FALSE       : return "CHECK_UNARY_FALSE";
-        case assertType::DT_REQUIRE_UNARY_FALSE     : return "REQUIRE_UNARY_FALSE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY_FALSE);
+
+        default: DOCTEST_INTERNAL_ERROR("Tried stringifying invalid assert type!");
     }
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    return "";
 }
 // clang-format on
 
 const char* failureString(assertType::Enum at) {
-    if(at & assertType::is_warn) //!OCLINT bitwise operator in conditional
-        return "WARNING";
-    if(at & assertType::is_check) //!OCLINT bitwise operator in conditional
-        return "ERROR";
-    if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
-        return "FATAL ERROR";
-    return "";
+  if(at & assertType::is_warn) //!OCLINT bitwise operator in conditional
+    return "WARNING";
+  if(at & assertType::is_check) //!OCLINT bitwise operator in conditional
+    return "ERROR";
+  if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
+    return "FATAL ERROR";
+  return "";
 }
 
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 // depending on the current options this will remove the path of filenames
 const char* skipPathFromFilename(const char* file) {
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
-        auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
-                forward = back;
-            return forward + 1;
-        }
+#ifndef DOCTEST_CONFIG_DISABLE
+  if(getContextOptions()->no_path_in_filenames) {
+    auto back    = std::strrchr(file, '\\');
+    auto forward = std::strrchr(file, '/');
+    if(back || forward) {
+      if(back > forward)
+        forward = back;
+      return forward + 1;
     }
-    return file;
+  }
+#endif // DOCTEST_CONFIG_DISABLE
+  return file;
 }
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    if(std::strcmp(m_file, other.m_file) != 0)
-        return std::strcmp(m_file, other.m_file) < 0;
-    return std::strcmp(m_name, other.m_name) < 0;
+bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+  return m_line == other.m_line
+         && std::strcmp(m_file, other.m_file) == 0
+         && m_name == other.m_name;
 }
 
-IContextScope::IContextScope()  = default;
-IContextScope::~IContextScope() = default;
+bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
+  if(m_line != other.m_line)
+    return m_line < other.m_line;
+  if(std::strcmp(m_file, other.m_file) != 0)
+    return std::strcmp(m_file, other.m_file) < 0;
+  return m_name.compare(other.m_name) < 0;
+}
+
+DOCTEST_DEFINE_INTERFACE(IContextScope)
+
+namespace detail {
+void filldata<const void*>::fill(std::ostream* stream, const void* in) {
+  if (in) { *stream << in; }
+  else { *stream << "nullptr"; }
+}
+
+template <typename T>
+String toStreamLit(T t) {
+  std::ostream* os = tlssPush();
+  os->operator<<(t);
+  return tlssPop();
+}
+}
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(char* in) { return toString(static_cast<const char*>(in)); }
 String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(bool in) { return in ? "true" : "false"; }
-String toString(float in) { return fpToString(in, 5) + "f"; }
-String toString(double in) { return fpToString(in, 10); }
-String toString(double long in) { return fpToString(in, 15); }
-
-#define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
-    String toString(type in) {                                                                     \
-        char buf[64];                                                                              \
-        std::sprintf(buf, fmt, in);                                                                \
-        return buf;                                                                                \
-    }
-
-DOCTEST_TO_STRING_OVERLOAD(char, "%d")
-DOCTEST_TO_STRING_OVERLOAD(char signed, "%d")
-DOCTEST_TO_STRING_OVERLOAD(char unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int short, "%d")
-DOCTEST_TO_STRING_OVERLOAD(int short unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int, "%d")
-DOCTEST_TO_STRING_OVERLOAD(unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int long, "%ld")
-DOCTEST_TO_STRING_OVERLOAD(int long unsigned, "%lu")
-DOCTEST_TO_STRING_OVERLOAD(int long long, "%lld")
-DOCTEST_TO_STRING_OVERLOAD(int long long unsigned, "%llu")
-
-String toString(std::nullptr_t) { return "NULL"; }
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 String toString(const std::string& in) { return in.c_str(); }
 #endif // VS 2019
 
+String toString(String in) { return in; }
+
+String toString(std::nullptr_t) { return "nullptr"; }
+
+String toString(bool in) { return in ? "true" : "false"; }
+
+String toString(float in) { return toStreamLit(in); }
+String toString(double in) { return toStreamLit(in); }
+String toString(double long in) { return toStreamLit(in); }
+
+String toString(char in) { return toStreamLit(static_cast<signed>(in)); }
+String toString(char signed in) { return toStreamLit(static_cast<signed>(in)); }
+String toString(char unsigned in) { return toStreamLit(static_cast<unsigned>(in)); }
+String toString(short in) { return toStreamLit(in); }
+String toString(short unsigned in) { return toStreamLit(in); }
+String toString(signed in) { return toStreamLit(in); }
+String toString(unsigned in) { return toStreamLit(in); }
+String toString(long in) { return toStreamLit(in); }
+String toString(long unsigned in) { return toStreamLit(in); }
+String toString(long long in) { return toStreamLit(in); }
+String toString(long long unsigned in) { return toStreamLit(in); }
+
 Approx::Approx(double value)
-        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
-        , m_scale(1.0)
-        , m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
+      , m_scale(1.0)
+      , m_value(value) {}
 
 Approx Approx::operator()(double value) const {
-    Approx approx(value);
-    approx.epsilon(m_epsilon);
-    approx.scale(m_scale);
-    return approx;
+  Approx approx(value);
+  approx.epsilon(m_epsilon);
+  approx.scale(m_scale);
+  return approx;
 }
 
 Approx& Approx::epsilon(double newEpsilon) {
-    m_epsilon = newEpsilon;
-    return *this;
+  m_epsilon = newEpsilon;
+  return *this;
 }
 Approx& Approx::scale(double newScale) {
-    m_scale = newScale;
-    return *this;
+  m_scale = newScale;
+  return *this;
 }
 
 bool operator==(double lhs, const Approx& rhs) {
-    // Thanks to Richard Harris for his help refining this formula
-    return std::fabs(lhs - rhs.m_value) <
-           rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
+  // Thanks to Richard Harris for his help refining this formula
+  return std::fabs(lhs - rhs.m_value) <
+         rhs.m_epsilon * (rhs.m_scale + std::max<double>(std::fabs(lhs), std::fabs(rhs.m_value)));
 }
 bool operator==(const Approx& lhs, double rhs) { return operator==(rhs, lhs); }
 bool operator!=(double lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
@@ -3353,9 +3946,24 @@ bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs 
 bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
 String toString(const Approx& in) {
-    return String("Approx( ") + doctest::toString(in.m_value) + " )";
+  return "Approx( " + doctest::toString(in.m_value) + " )";
 }
 const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, g_cs); }
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4738)
+template <typename F>
+IsNaN<F>::operator bool() const {
+  return std::isnan(value) ^ flipped;
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+template struct DOCTEST_INTERFACE_DEF IsNaN<float>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
+template <typename F>
+String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
+String toString(IsNaN<float> in) { return toString<float>(in); }
+String toString(IsNaN<double> in) { return toString<double>(in); }
+String toString(IsNaN<double long> in) { return toString<double long>(in); }
 
 } // namespace doctest
 
@@ -3366,14 +3974,14 @@ Context::~Context() = default;
 void Context::applyCommandLine(int, const char* const*) {}
 void Context::addFilter(const char*, const char*) {}
 void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
 void Context::setOption(const char*, int) {}
 void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
 void Context::setAsDefaultForAssertsOutOfTestCases() {}
 void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream*) {}
 int  Context::run() { return 0; }
-
-IReporter::~IReporter() = default;
 
 int                         IReporter::get_num_active_contexts() { return 0; }
 const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
@@ -3398,328 +4006,346 @@ int registerReporter(const char*, int, IReporter*) { return 0; }
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite
 doctest::detail::TestSuite& getCurrentTestSuite() {
-    static doctest::detail::TestSuite data;
-    return data;
+  static doctest::detail::TestSuite data{};
+  return data;
 }
 } // namespace doctest_detail_test_suite_ns
 
 namespace doctest {
 namespace {
-    // the int (priority) is part of the key for automatic sorting - sadly one can register a
-    // reporter with a duplicate name and a different priority but hopefully that won't happen often :|
-    typedef std::map<std::pair<int, String>, reporterCreatorFunc> reporterMap;
+// the int (priority) is part of the key for automatic sorting - sadly one can register a
+// reporter with a duplicate name and a different priority but hopefully that won't happen often :|
+using reporterMap = std::map<std::pair<int, String>, reporterCreatorFunc>;
 
-    reporterMap& getReporters() {
-        static reporterMap data;
-        return data;
-    }
-    reporterMap& getListeners() {
-        static reporterMap data;
-        return data;
-    }
+reporterMap& getReporters() {
+  static reporterMap data;
+  return data;
+}
+reporterMap& getListeners() {
+  static reporterMap data;
+  return data;
+}
 } // namespace
 namespace detail {
 #define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                           \
     for(auto& curr_rep : g_cs->reporters_currently_used)                                           \
     curr_rep->function(__VA_ARGS__)
 
-    bool checkIfShouldThrow(assertType::Enum at) {
-        if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
-            return true;
+bool checkIfShouldThrow(assertType::Enum at) {
+  if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
+    return true;
 
-        if((at & assertType::is_check) //!OCLINT bitwise operator in conditional
-           && getContextOptions()->abort_after > 0 &&
-           (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >=
-                   getContextOptions()->abort_after)
-            return true;
+  if((at & assertType::is_check) //!OCLINT bitwise operator in conditional
+      && getContextOptions()->abort_after > 0 &&
+      (g_cs->numAssertsFailed + g_cs->numAssertsFailedCurrentTest_atomic) >=
+          getContextOptions()->abort_after)
+    return true;
 
-        return false;
-    }
+  return false;
+}
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    [[noreturn]] void throwException() {
-        g_cs->shouldLogCurrentException = false;
-        throw TestFailureException();
-    } // NOLINT(cert-err60-cpp)
+DOCTEST_NORETURN void throwException() {
+  g_cs->shouldLogCurrentException = false;
+  throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
+}
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS
-    void throwException() {}
+void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
 } // namespace detail
 
 namespace {
-    using namespace detail;
-    // matching of a string against a wildcard mask (case sensitivity configurable) taken from
-    // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
-    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
-        const char* cp = nullptr;
-        const char* mp = nullptr;
+using namespace detail;
+// matching of a string against a wildcard mask (case sensitivity configurable) taken from
+// https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
+int wildcmp(const char* str, const char* wild, bool caseSensitive) {
+  const char* cp = str;
+  const char* mp = wild;
 
-        while((*str) && (*wild != '*')) {
-            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
-               (*wild != '?')) {
-                return 0;
-            }
-            wild++;
-            str++;
-        }
-
-        while(*str) {
-            if(*wild == '*') {
-                if(!*++wild) {
-                    return 1;
-                }
-                mp = wild;
-                cp = str + 1;
-            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
-                      (*wild == '?')) {
-                wild++;
-                str++;
-            } else {
-                wild = mp;   //!OCLINT parameter reassignment
-                str  = cp++; //!OCLINT parameter reassignment
-            }
-        }
-
-        while(*wild == '*') {
-            wild++;
-        }
-        return !*wild;
+  while((*str) && (*wild != '*')) {
+    if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
+        (*wild != '?')) {
+      return 0;
     }
+    wild++;
+    str++;
+  }
 
-    //// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-    //unsigned hashStr(unsigned const char* str) {
-    //    unsigned long hash = 5381;
-    //    char          c;
-    //    while((c = *str++))
-    //        hash = ((hash << 5) + hash) + c; // hash * 33 + c
-    //    return hash;
-    //}
-
-    // checks if the name matches any of the filters (and can be configured what to do when empty)
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-                    bool caseSensitive) {
-        if(filters.empty() && matchEmpty)
-            return true;
-        for(auto& curr : filters)
-            if(wildcmp(name, curr.c_str(), caseSensitive))
-                return true;
-        return false;
+  while(*str) {
+    if(*wild == '*') {
+      if(!*++wild) {
+        return 1;
+      }
+      mp = wild;
+      cp = str + 1;
+    } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
+               (*wild == '?')) {
+      wild++;
+      str++;
+    } else {
+      wild = mp;   //!OCLINT parameter reassignment
+      str  = cp++; //!OCLINT parameter reassignment
     }
+  }
+
+  while(*wild == '*') {
+    wild++;
+  }
+  return !*wild;
+}
+
+// checks if the name matches any of the filters (and can be configured what to do when empty)
+bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
+                bool caseSensitive) {
+  if (filters.empty() && matchEmpty)
+    return true;
+  for (auto& curr : filters)
+    if (wildcmp(name, curr.c_str(), caseSensitive))
+      return true;
+  return false;
+}
+
+unsigned long long hash(unsigned long long a, unsigned long long b) {
+  return (a << 5) + b;
+}
+
+// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+unsigned long long hash(const char* str) {
+  unsigned long long hash = 5381;
+  char c;
+  while ((c = *str++))
+    hash = ((hash << 5) + hash) + c; // hash * 33 + c
+  return hash;
+}
+
+unsigned long long hash(const SubcaseSignature& sig) {
+  return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
+}
+
+unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
+  unsigned long long running = 0;
+  auto end = sigs.begin() + count;
+  for (auto it = sigs.begin(); it != end; it++) {
+    running = hash(running, hash(*it));
+  }
+  return running;
+}
+
+unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
+  unsigned long long running = 0;
+  for (const SubcaseSignature& sig : sigs) {
+    running = hash(running, hash(sig));
+  }
+  return running;
+}
 } // namespace
 namespace detail {
+bool Subcase::checkFilters() {
+  if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+    if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+      return true;
+    if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+      return true;
+  }
+  return false;
+}
 
-    Subcase::Subcase(const char* name, const char* file, int line)
-            : m_signature({name, file, line}) {
-        ContextState* s = g_cs;
+Subcase::Subcase(const String& name, const char* file, int line)
+    : m_signature({name, file, line}) {
+  if (!g_cs->reachedLeaf) {
+    if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
+        || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+      // Going down.
+      if (checkFilters()) { return; }
 
-        // check subcase filters
-        if(s->subcasesStack.size() < size_t(s->subcase_filter_levels)) {
-            if(!matchesAny(m_signature.m_name, s->filters[6], true, s->case_sensitive))
-                return;
-            if(matchesAny(m_signature.m_name, s->filters[7], false, s->case_sensitive))
-                return;
-        }
-        
-        // if a Subcase on the same level has already been entered
-        if(s->subcasesStack.size() < size_t(s->subcasesCurrentMaxLevel)) {
-            s->should_reenter = true;
-            return;
-        }
+      g_cs->subcaseStack.push_back(m_signature);
+      g_cs->currentSubcaseDepth++;
+      m_entered = true;
+      DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+    }
+  } else {
+    if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+      // This subcase is reentered via control flow.
+      g_cs->currentSubcaseDepth++;
+      m_entered = true;
+      DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+    } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
+               && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
+                      == g_cs->fullyTraversedSubcases.end()) {
+      if (checkFilters()) { return; }
+      // This subcase is part of the one to be executed next.
+      g_cs->nextSubcaseStack.clear();
+      g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
+                                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+      g_cs->nextSubcaseStack.push_back(m_signature);
+    }
+  }
+}
 
-        // push the current signature to the stack so we can check if the
-        // current stack + the current new subcase have been traversed
-        s->subcasesStack.push_back(m_signature);
-        if(s->subcasesPassed.count(s->subcasesStack) != 0) {
-            // pop - revert to previous stack since we've already passed this
-            s->subcasesStack.pop_back();
-            return;
-        }
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 
-        s->subcasesCurrentMaxLevel = s->subcasesStack.size();
-        m_entered = true;
+Subcase::~Subcase() {
+  if (m_entered) {
+    g_cs->currentSubcaseDepth--;
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+    if (!g_cs->reachedLeaf) {
+      // Leaf.
+      g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+      g_cs->nextSubcaseStack.clear();
+      g_cs->reachedLeaf = true;
+    } else if (g_cs->nextSubcaseStack.empty()) {
+      // All children are finished.
+      g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
     }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    Subcase::~Subcase() {
-        if(m_entered) {
-            // only mark the subcase stack as passed if no subcases have been skipped
-            if(g_cs->should_reenter == false)
-                g_cs->subcasesPassed.insert(g_cs->subcasesStack);
-            g_cs->subcasesStack.pop_back();
-
-            if(std::uncaught_exception() && g_cs->shouldLogCurrentException) {
-                DOCTEST_ITERATE_THROUGH_REPORTERS(
-                        test_case_exception, {"exception thrown in subcase - will translate later "
-                                              "when the whole test case has been exited (cannot "
-                                              "translate while there is an active exception)",
-                                              false});
-                g_cs->shouldLogCurrentException = false;
-            }
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
-    }
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
-    Subcase::operator bool() const { return m_entered; }
-
-    Result::Result(bool passed, const String& decomposition)
-            : m_passed(passed)
-            , m_decomp(decomposition) {}
-
-    ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-            : m_at(at) {}
-
-    TestSuite& TestSuite::operator*(const char* in) {
-        m_test_suite = in;
-        // clear state
-        m_description       = nullptr;
-        m_skip              = false;
-        m_may_fail          = false;
-        m_should_fail       = false;
-        m_expected_failures = 0;
-        m_timeout           = 0;
-        return *this;
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+    if(std::uncaught_exceptions() > 0
+#else
+    if(std::uncaught_exception()
+#endif
+        && g_cs->shouldLogCurrentException) {
+      DOCTEST_ITERATE_THROUGH_REPORTERS(
+          test_case_exception, {"exception thrown in subcase - will translate later "
+                                "when the whole test case has been exited (cannot "
+                                "translate while there is an active exception)",
+                                false});
+      g_cs->shouldLogCurrentException = false;
     }
 
-    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                       const char* type, int template_id) {
-        m_file              = file;
-        m_line              = line;
-        m_name              = nullptr; // will be later overridden in operator*
-        m_test_suite        = test_suite.m_test_suite;
-        m_description       = test_suite.m_description;
-        m_skip              = test_suite.m_skip;
-        m_may_fail          = test_suite.m_may_fail;
-        m_should_fail       = test_suite.m_should_fail;
-        m_expected_failures = test_suite.m_expected_failures;
-        m_timeout           = test_suite.m_timeout;
+    DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+  }
+}
 
-        m_test        = test;
-        m_type        = type;
-        m_template_id = template_id;
-    }
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    TestCase::TestCase(const TestCase& other)
-            : TestCaseData() {
-        *this = other;
-    }
+Subcase::operator bool() const { return m_entered; }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-    DOCTEST_MSVC_SUPPRESS_WARNING(26437)           // Do not slice
-    TestCase& TestCase::operator=(const TestCase& other) {
-        static_cast<TestCaseData&>(*this) = static_cast<const TestCaseData&>(other);
+Result::Result(bool passed, const String& decomposition)
+    : m_passed(passed)
+      , m_decomp(decomposition) {}
 
-        m_test        = other.m_test;
-        m_type        = other.m_type;
-        m_template_id = other.m_template_id;
-        m_full_name   = other.m_full_name;
+ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
+    : m_at(at) {}
 
-        if(m_template_id != -1)
-            m_name = m_full_name.c_str();
-        return *this;
-    }
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+TestSuite& TestSuite::operator*(const char* in) {
+  m_test_suite = in;
+  return *this;
+}
 
-    TestCase& TestCase::operator*(const char* in) {
-        m_name = in;
-        // make a new name with an appended type for templated test case
-        if(m_template_id != -1) {
-            m_full_name = String(m_name) + m_type;
-            // redirect the name to point to the newly constructed full name
-            m_name = m_full_name.c_str();
-        }
-        return *this;
-    }
+TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
+                   const String& type, int template_id) {
+  m_file              = file;
+  m_line              = line;
+  m_name              = nullptr; // will be later overridden in operator*
+  m_test_suite        = test_suite.m_test_suite;
+  m_description       = test_suite.m_description;
+  m_skip              = test_suite.m_skip;
+  m_no_breaks         = test_suite.m_no_breaks;
+  m_no_output         = test_suite.m_no_output;
+  m_may_fail          = test_suite.m_may_fail;
+  m_should_fail       = test_suite.m_should_fail;
+  m_expected_failures = test_suite.m_expected_failures;
+  m_timeout           = test_suite.m_timeout;
 
-    bool TestCase::operator<(const TestCase& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
-        const int file_cmp = std::strcmp(m_file, other.m_file);
-        if(file_cmp != 0)
-            return file_cmp < 0;
-        return m_template_id < other.m_template_id;
-    }
+  m_test        = test;
+  m_type        = type;
+  m_template_id = template_id;
+}
+
+TestCase::TestCase(const TestCase& other)
+    : TestCaseData() {
+  *this = other;
+}
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+TestCase& TestCase::operator=(const TestCase& other) {
+  TestCaseData::operator=(other);
+  m_test        = other.m_test;
+  m_type        = other.m_type;
+  m_template_id = other.m_template_id;
+  m_full_name   = other.m_full_name;
+
+  if(m_template_id != -1)
+    m_name = m_full_name.c_str();
+  return *this;
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+TestCase& TestCase::operator*(const char* in) {
+  m_name = in;
+  // make a new name with an appended type for templated test case
+  if(m_template_id != -1) {
+    m_full_name = String(m_name) + "<" + m_type + ">";
+    // redirect the name to point to the newly constructed full name
+    m_name = m_full_name.c_str();
+  }
+  return *this;
+}
+
+bool TestCase::operator<(const TestCase& other) const {
+  // this will be used only to differentiate between test cases - not relevant for sorting
+  if(m_line != other.m_line)
+    return m_line < other.m_line;
+  const int name_cmp = strcmp(m_name, other.m_name);
+  if(name_cmp != 0)
+    return name_cmp < 0;
+  const int file_cmp = m_file.compare(other.m_file);
+  if(file_cmp != 0)
+    return file_cmp < 0;
+  return m_template_id < other.m_template_id;
+}
+
+// all the registered tests
+std::set<TestCase>& getRegisteredTests() {
+  static std::set<TestCase> data;
+  return data;
+}
 } // namespace detail
 namespace {
-    using namespace detail;
-    // for sorting tests by file/line
-    bool fileOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-#if DOCTEST_MSVC
-        // this is needed because MSVC gives different case for drive letters
-        // for __FILE__ when evaluated in a header and a source file
-        const int res = stricmp(lhs->m_file, rhs->m_file);
-#else  // MSVC
-        const int res = std::strcmp(lhs->m_file, rhs->m_file);
-#endif // MSVC
-        if(res != 0)
-            return res < 0;
-        if(lhs->m_line != rhs->m_line)
-            return lhs->m_line < rhs->m_line;
-        return lhs->m_template_id < rhs->m_template_id;
-    }
+using namespace detail;
+// for sorting tests by file/line
+bool fileOrderComparator(const TestCase* lhs, const TestCase* rhs) {
+  // this is needed because MSVC gives different case for drive letters
+  // for __FILE__ when evaluated in a header and a source file
+  const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
+  if(res != 0)
+    return res < 0;
+  if(lhs->m_line != rhs->m_line)
+    return lhs->m_line < rhs->m_line;
+  return lhs->m_template_id < rhs->m_template_id;
+}
 
-    // for sorting tests by suite/file/line
-    bool suiteOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-        if(res != 0)
-            return res < 0;
-        return fileOrderComparator(lhs, rhs);
-    }
+// for sorting tests by suite/file/line
+bool suiteOrderComparator(const TestCase* lhs, const TestCase* rhs) {
+  const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
+  if(res != 0)
+    return res < 0;
+  return fileOrderComparator(lhs, rhs);
+}
 
-    // for sorting tests by name/suite/file/line
-    bool nameOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-        const int res = std::strcmp(lhs->m_name, rhs->m_name);
-        if(res != 0)
-            return res < 0;
-        return suiteOrderComparator(lhs, rhs);
-    }
+// for sorting tests by name/suite/file/line
+bool nameOrderComparator(const TestCase* lhs, const TestCase* rhs) {
+  const int res = std::strcmp(lhs->m_name, rhs->m_name);
+  if(res != 0)
+    return res < 0;
+  return suiteOrderComparator(lhs, rhs);
+}
 
-    // all the registered tests
-    std::set<TestCase>& getRegisteredTests() {
-        static std::set<TestCase> data;
-        return data;
-    }
-
-#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-    HANDLE g_stdoutHandle;
-    WORD   g_origFgAttrs;
-    WORD   g_origBgAttrs;
-    bool   g_attrsInitted = false;
-
-    int colors_init() {
-        if(!g_attrsInitted) {
-            g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-            g_attrsInitted = true;
-            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-            GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
-            g_origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                                                     BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-            g_origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                                                     FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-        }
-        return 0;
-    }
-
-    int dumy_init_console_colors = colors_init();
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
-
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    void color_to_stream(std::ostream& s, Color::Enum code) {
-        ((void)s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
-        ((void)code); // for DOCTEST_CONFIG_COLORS_NONE
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+void color_to_stream(std::ostream& s, Color::Enum code) {
+  static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+  static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
 #ifdef DOCTEST_CONFIG_COLORS_ANSI
-        if(g_no_colors ||
-           (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
-            return;
+  if(g_no_colors ||
+      (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
+    return;
 
-        auto col = "";
-        // clang-format off
+  auto col = "";
+  // clang-format off
             switch(code) { //!OCLINT missing break in switch statement / unnecessary default statement in covered switch statement
                 case Color::Red:         col = "[0;31m"; break;
                 case Color::Green:       col = "[0;32m"; break;
@@ -3736,18 +4362,34 @@ namespace {
                 case Color::White:
                 default:                 col = "[0m";
             }
-        // clang-format on
-        s << "\033" << col;
+  // clang-format on
+  s << "\033" << col;
 #endif // DOCTEST_CONFIG_COLORS_ANSI
 
 #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(g_no_colors ||
-           (isatty(fileno(stdout)) == false && getContextOptions()->force_colors == false))
-            return;
+  if(g_no_colors ||
+      (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
+    return;
 
-#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(g_stdoutHandle, x | g_origBgAttrs)
+  static struct ConsoleHelper {
+    HANDLE stdoutHandle;
+    WORD   origFgAttrs;
+    WORD   origBgAttrs;
 
-        // clang-format off
+    ConsoleHelper() {
+      stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+      CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+      GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+      origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
+                                             BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+      origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
+                                             FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+    }
+  } ch;
+
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
+
+  // clang-format off
         switch (code) {
             case Color::White:       DOCTEST_SET_ATTR(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
             case Color::Red:         DOCTEST_SET_ATTR(FOREGROUND_RED);                                      break;
@@ -3762,26 +4404,26 @@ namespace {
             case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
             case Color::None:
             case Color::Bright: // invalid
-            default:                 DOCTEST_SET_ATTR(g_origFgAttrs);
+            default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
         }
-            // clang-format on
+  // clang-format on
 #endif // DOCTEST_CONFIG_COLORS_WINDOWS
-    }
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+}
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
-        static std::vector<const IExceptionTranslator*> data;
-        return data;
-    }
+std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
+  static std::vector<const IExceptionTranslator*> data;
+  return data;
+}
 
-    String translateActiveException() {
+String translateActiveException() {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        String res;
-        auto&  translators = getExceptionTranslators();
-        for(auto& curr : translators)
-            if(curr->translate(res))
-                return res;
-        // clang-format off
+  String res;
+  auto&  translators = getExceptionTranslators();
+  for(auto& curr : translators)
+    if(curr->translate(res))
+      return res;
+  // clang-format off
         DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcatch-value")
         try {
             throw;
@@ -3797,266 +4439,366 @@ namespace {
         DOCTEST_GCC_SUPPRESS_WARNING_POP
 // clang-format on
 #else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        return "";
+  return "";
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
+}
 } // namespace
 
 namespace detail {
-    // used by the macros for registering tests
-    int regTest(const TestCase& tc) {
-        getRegisteredTests().insert(tc);
-        return 0;
-    }
+// used by the macros for registering tests
+int regTest(const TestCase& tc) {
+  getRegisteredTests().insert(tc);
+  return 0;
+}
 
-    // sets the current test suite
-    int setTestSuite(const TestSuite& ts) {
-        doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
-        return 0;
-    }
+// sets the current test suite
+int setTestSuite(const TestSuite& ts) {
+  doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
+  return 0;
+}
 
 #ifdef DOCTEST_IS_DEBUGGER_ACTIVE
-    bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
+bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
 #else // DOCTEST_IS_DEBUGGER_ACTIVE
-#ifdef DOCTEST_PLATFORM_MAC
-    // The following function is taken directly from the following technical note:
-    // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
-    // Returns true if the current process is being debugged (either
-    // running under the debugger or has a debugger attached post facto).
-    bool isDebuggerActive() {
-        int        mib[4];
-        kinfo_proc info;
-        size_t     size;
-        // Initialize the flags so that, if sysctl fails for some bizarre
-        // reason, we get a predictable result.
-        info.kp_proc.p_flag = 0;
-        // Initialize mib, which tells sysctl the info we want, in this case
-        // we're looking for information about a specific process ID.
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROC;
-        mib[2] = KERN_PROC_PID;
-        mib[3] = getpid();
-        // Call sysctl.
-        size = sizeof(info);
-        if(sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, 0, 0) != 0) {
-            std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
-            return false;
-        }
-        // We're being debugged if the P_TRACED flag is set.
-        return ((info.kp_proc.p_flag & P_TRACED) != 0);
+#ifdef DOCTEST_PLATFORM_LINUX
+class ErrnoGuard {
+public:
+  ErrnoGuard() : m_oldErrno(errno) {}
+  ~ErrnoGuard() { errno = m_oldErrno; }
+private:
+  int m_oldErrno;
+};
+// See the comments in Catch2 for the reasoning behind this implementation:
+// https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
+bool isDebuggerActive() {
+  ErrnoGuard guard;
+  std::ifstream in("/proc/self/status");
+  for(std::string line; std::getline(in, line);) {
+    static const int PREFIX_LEN = 11;
+    if(line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+      return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
     }
-#elif DOCTEST_MSVC || defined(__MINGW32__)
-    bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
+  }
+  return false;
+}
+#elif defined(DOCTEST_PLATFORM_MAC)
+// The following function is taken directly from the following technical note:
+// https://developer.apple.com/library/archive/qa/qa1361/_index.html
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive() {
+  int        mib[4];
+  kinfo_proc info;
+  size_t     size;
+  // Initialize the flags so that, if sysctl fails for some bizarre
+  // reason, we get a predictable result.
+  info.kp_proc.p_flag = 0;
+  // Initialize mib, which tells sysctl the info we want, in this case
+  // we're looking for information about a specific process ID.
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PID;
+  mib[3] = getpid();
+  // Call sysctl.
+  size = sizeof(info);
+  if(sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, 0, 0) != 0) {
+    std::cerr << "\nCall to sysctl failed - unable to determine if debugger is active **\n";
+    return false;
+  }
+  // We're being debugged if the P_TRACED flag is set.
+  return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
+#elif DOCTEST_MSVC || defined(__MINGW32__) || defined(__MINGW64__)
+bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
 #else
-    bool isDebuggerActive() { return false; }
+bool isDebuggerActive() { return false; }
 #endif // Platform
 #endif // DOCTEST_IS_DEBUGGER_ACTIVE
 
-    void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
-        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
-           getExceptionTranslators().end())
-            getExceptionTranslators().push_back(et);
-    }
+void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
+  if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
+      getExceptionTranslators().end())
+    getExceptionTranslators().push_back(et);
+}
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* s, char* in) { *s << in; }
-    void toStream(std::ostream* s, const char* in) { *s << in; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* s, bool in) { *s << std::boolalpha << in << std::noboolalpha; }
-    void toStream(std::ostream* s, float in) { *s << in; }
-    void toStream(std::ostream* s, double in) { *s << in; }
-    void toStream(std::ostream* s, double long in) { *s << in; }
+DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
-    void toStream(std::ostream* s, char in) { *s << in; }
-    void toStream(std::ostream* s, char signed in) { *s << in; }
-    void toStream(std::ostream* s, char unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int short in) { *s << in; }
-    void toStream(std::ostream* s, int short unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int in) { *s << in; }
-    void toStream(std::ostream* s, int unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int long in) { *s << in; }
-    void toStream(std::ostream* s, int long unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int long long in) { *s << in; }
-    void toStream(std::ostream* s, int long long unsigned in) { *s << in; }
+ContextScopeBase::ContextScopeBase() {
+  g_infoContexts.push_back(this);
+}
 
-    DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
+ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
+  if (other.need_to_destroy) {
+    other.destroy();
+  }
+  other.need_to_destroy = false;
+  g_infoContexts.push_back(this);
+}
 
-    ContextScopeBase::ContextScopeBase() {
-        g_infoContexts.push_back(this);
-    }
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
-    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    // destroy cannot be inlined into the destructor because that would mean calling stringify after
-    // ContextScope has been destroyed (base class destructors run after derived class destructors).
-    // Instead, ContextScope calls this method directly from its destructor.
-    void ContextScopeBase::destroy() {
-        if(std::uncaught_exception()) {
-            std::ostringstream s;
-            this->stringify(&s);
-            g_cs->stringifiedContexts.push_back(s.str().c_str());
-        }
-        g_infoContexts.pop_back();
-    }
-    DOCTEST_CLANG_SUPPRESS_WARNING_POP
-    DOCTEST_GCC_SUPPRESS_WARNING_POP
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+// destroy cannot be inlined into the destructor because that would mean calling stringify after
+// ContextScope has been destroyed (base class destructors run after derived class destructors).
+// Instead, ContextScope calls this method directly from its destructor.
+void ContextScopeBase::destroy() {
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+  if(std::uncaught_exceptions() > 0) {
+#else
+  if(std::uncaught_exception()) {
+#endif
+    std::ostringstream s;
+    this->stringify(&s);
+    g_cs->stringifiedContexts.push_back(s.str().c_str());
+  }
+  g_infoContexts.pop_back();
+}
 
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+DOCTEST_GCC_SUPPRESS_WARNING_POP
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 } // namespace detail
 namespace {
-    using namespace detail;
-
-    std::ostream& file_line_to_stream(std::ostream& s, const char* file, int line,
-                                      const char* tail = "") {
-        const auto opt = getContextOptions();
-        s << Color::LightGrey << skipPathFromFilename(file) << (opt->gnu_file_line ? ":" : "(")
-          << (opt->no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-          << (opt->gnu_file_line ? ":" : "):") << tail;
-        return s;
-    }
+using namespace detail;
 
 #if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    struct FatalConditionHandler
-    {
-        void reset() {}
-    };
+struct FatalConditionHandler
+{
+  static void reset() {}
+  static void allocateAltStackMem() {}
+  static void freeAltStackMem() {}
+};
 #else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-    void reportFatal(const std::string&);
+void reportFatal(const std::string&);
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
+struct SignalDefs
+{
+  DWORD id;
+  const char* name;
+};
+// There is no 1-1 mapping between signals and windows exceptions.
+// Windows can easily distinguish between SO and SigSegV,
+// but SigInt, SigTerm, etc are handled differently.
+SignalDefs signalDefs[] = {
+    {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),
+     "SIGILL - Illegal instruction signal"},
+    {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
+    {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION),
+     "SIGSEGV - Segmentation violation signal"},
+    {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
+};
+
+struct FatalConditionHandler
+{
+  static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo) {
+    // Multiple threads may enter this filter/handler at once. We want the error message to be printed on the
+    // console just once no matter how many threads have crashed.
+    DOCTEST_DECLARE_STATIC_MUTEX(mutex)
+    static bool execute = true;
     {
-        DWORD id;
-        const char* name;
-    };
-    // There is no 1-1 mapping between signals and windows exceptions.
-    // Windows can easily distinguish between SO and SigSegV,
-    // but SigInt, SigTerm, etc are handled differently.
-    SignalDefs signalDefs[] = {
-            {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
-            {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
-            {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
-            {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
-    };
-
-    struct FatalConditionHandler
-    {
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
-            for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
-                    reportFatal(signalDefs[i].name);
-                }
-            }
-            // If its not an exception we care about, pass it along.
-            // This stops us from eating debugger breaks etc.
-            return EXCEPTION_CONTINUE_SEARCH;
+      DOCTEST_LOCK_MUTEX(mutex)
+      if(execute) {
+        bool reported = false;
+        for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+          if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+            reportFatal(signalDefs[i].name);
+            reported = true;
+            break;
+          }
         }
+        if(reported == false)
+          reportFatal("Unhandled SEH exception caught");
+        if(isDebuggerActive() && !g_cs->no_breaks)
+          DOCTEST_BREAK_INTO_DEBUGGER();
+      }
+      execute = false;
+    }
+    std::exit(EXIT_FAILURE);
+  }
 
-        FatalConditionHandler() {
-            isSet = true;
-            // 32k seems enough for doctest to handle stack overflow,
-            // but the value was found experimentally, so there is no strong guarantee
-            guaranteeSize = 32 * 1024;
-            exceptionHandlerHandle = nullptr;
-            // Register as first handler in current chain
-            exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-            // Pass in guarantee size to be filled
-            SetThreadStackGuarantee(&guaranteeSize);
-        }
+  static void allocateAltStackMem() {}
+  static void freeAltStackMem() {}
 
-        static void reset() {
-            if(isSet) {
-                // Unregister handler and restore the old guarantee
-                RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-                SetThreadStackGuarantee(&guaranteeSize);
-                exceptionHandlerHandle = nullptr;
-                isSet = false;
-            }
-        }
+  FatalConditionHandler() {
+    isSet = true;
+    // 32k seems enough for doctest to handle stack overflow,
+    // but the value was found experimentally, so there is no strong guarantee
+    guaranteeSize = 32 * 1024;
+    // Register an unhandled exception filter
+    previousTop = SetUnhandledExceptionFilter(handleException);
+    // Pass in guarantee size to be filled
+    SetThreadStackGuarantee(&guaranteeSize);
 
-        ~FatalConditionHandler() { reset(); }
+    // On Windows uncaught exceptions from another thread, exceptions from
+    // destructors, or calls to std::terminate are not a SEH exception
 
-    private:
-        static bool isSet;
-        static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
-    };
+    // The terminal handler gets called when:
+    // - std::terminate is called FROM THE TEST RUNNER THREAD
+    // - an exception is thrown from a destructor FROM THE TEST RUNNER THREAD
+    original_terminate_handler = std::get_terminate();
+    std::set_terminate([]() DOCTEST_NOEXCEPT {
+      reportFatal("Terminate handler called");
+      if(isDebuggerActive() && !g_cs->no_breaks)
+        DOCTEST_BREAK_INTO_DEBUGGER();
+      std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
+    });
 
-    bool FatalConditionHandler::isSet = false;
-    ULONG FatalConditionHandler::guaranteeSize = 0;
-    PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+    // SIGABRT is raised when:
+    // - std::terminate is called FROM A DIFFERENT THREAD
+    // - an exception is thrown from a destructor FROM A DIFFERENT THREAD
+    // - an uncaught exception is thrown FROM A DIFFERENT THREAD
+    prev_sigabrt_handler = std::signal(SIGABRT, [](int signal) DOCTEST_NOEXCEPT {
+      if(signal == SIGABRT) {
+        reportFatal("SIGABRT - Abort (abnormal termination) signal");
+        if(isDebuggerActive() && !g_cs->no_breaks)
+          DOCTEST_BREAK_INTO_DEBUGGER();
+        std::exit(EXIT_FAILURE);
+      }
+    });
+
+    // The following settings are taken from google test, and more
+    // specifically from UnitTest::Run() inside of gtest.cc
+
+    // the user does not want to see pop-up dialogs about crashes
+    prev_error_mode_1 = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
+                                     SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    // This forces the abort message to go to stderr in all circumstances.
+    prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
+    // In the debug version, Visual Studio pops up a separate dialog
+    // offering a choice to debug the aborted program - we want to disable that.
+    prev_abort_behavior = _set_abort_behavior(0x0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    // In debug mode, the Windows CRT can crash with an assertion over invalid
+    // input (e.g. passing an invalid file descriptor). The default handling
+    // for these assertions is to pop up a dialog and wait for user input.
+    // Instead ask the CRT to dump such assertions to stderr non-interactively.
+    prev_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    prev_report_file = _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+  }
+
+  static void reset() {
+    if(isSet) {
+      // Unregister handler and restore the old guarantee
+      SetUnhandledExceptionFilter(previousTop);
+      SetThreadStackGuarantee(&guaranteeSize);
+      std::set_terminate(original_terminate_handler);
+      std::signal(SIGABRT, prev_sigabrt_handler);
+      SetErrorMode(prev_error_mode_1);
+      _set_error_mode(prev_error_mode_2);
+      _set_abort_behavior(prev_abort_behavior, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+      static_cast<void>(_CrtSetReportMode(_CRT_ASSERT, prev_report_mode));
+      static_cast<void>(_CrtSetReportFile(_CRT_ASSERT, prev_report_file));
+      isSet = false;
+    }
+  }
+
+  ~FatalConditionHandler() { reset(); }
+
+private:
+  static UINT         prev_error_mode_1;
+  static int          prev_error_mode_2;
+  static unsigned int prev_abort_behavior;
+  static int          prev_report_mode;
+  static _HFILE       prev_report_file;
+  static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
+  static std::terminate_handler original_terminate_handler;
+  static bool isSet;
+  static ULONG guaranteeSize;
+  static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
+};
+
+UINT         FatalConditionHandler::prev_error_mode_1;
+int          FatalConditionHandler::prev_error_mode_2;
+unsigned int FatalConditionHandler::prev_abort_behavior;
+int          FatalConditionHandler::prev_report_mode;
+_HFILE       FatalConditionHandler::prev_report_file;
+void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
+std::terminate_handler FatalConditionHandler::original_terminate_handler;
+bool FatalConditionHandler::isSet = false;
+ULONG FatalConditionHandler::guaranteeSize = 0;
+LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
-    struct SignalDefs
-    {
-        int         id;
-        const char* name;
-    };
-    SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
-                               {SIGILL, "SIGILL - Illegal instruction signal"},
-                               {SIGFPE, "SIGFPE - Floating point error signal"},
-                               {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-                               {SIGTERM, "SIGTERM - Termination request signal"},
-                               {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+struct SignalDefs
+{
+  int         id;
+  const char* name;
+};
+SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
+                           {SIGILL, "SIGILL - Illegal instruction signal"},
+                           {SIGFPE, "SIGFPE - Floating point error signal"},
+                           {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+                           {SIGTERM, "SIGTERM - Termination request signal"},
+                           {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
 
-    struct FatalConditionHandler
-    {
-        static bool             isSet;
-        static struct sigaction oldSigActions[DOCTEST_COUNTOF(signalDefs)];
-        static stack_t          oldSigStack;
-        static char             altStackMem[4 * SIGSTKSZ];
+struct FatalConditionHandler
+{
+  static bool             isSet;
+  static struct sigaction oldSigActions[DOCTEST_COUNTOF(signalDefs)];
+  static stack_t          oldSigStack;
+  static size_t           altStackSize;
+  static char*            altStackMem;
 
-        static void handleSignal(int sig) {
-            const char* name = "<unknown signal>";
-            for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                SignalDefs& def = signalDefs[i];
-                if(sig == def.id) {
-                    name = def.name;
-                    break;
-                }
-            }
-            reset();
-            reportFatal(name);
-            raise(sig);
-        }
+  static void handleSignal(int sig) {
+    const char* name = "<unknown signal>";
+    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+      SignalDefs& def = signalDefs[i];
+      if(sig == def.id) {
+        name = def.name;
+        break;
+      }
+    }
+    reset();
+    reportFatal(name);
+    raise(sig);
+  }
 
-        FatalConditionHandler() {
-            isSet = true;
-            stack_t sigStack;
-            sigStack.ss_sp    = altStackMem;
-            sigStack.ss_size  = sizeof(altStackMem);
-            sigStack.ss_flags = 0;
-            sigaltstack(&sigStack, &oldSigStack);
-            struct sigaction sa = {};
-            sa.sa_handler       = handleSignal; // NOLINT
-            sa.sa_flags         = SA_ONSTACK;
-            for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
-            }
-        }
+  static void allocateAltStackMem() {
+    altStackMem = new char[altStackSize];
+  }
 
-        ~FatalConditionHandler() { reset(); }
-        static void reset() {
-            if(isSet) {
-                // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-                for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                    sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
-                }
-                // Return the old stack
-                sigaltstack(&oldSigStack, nullptr);
-                isSet = false;
-            }
-        }
-    };
+  static void freeAltStackMem() {
+    delete[] altStackMem;
+  }
 
-    bool             FatalConditionHandler::isSet                                      = false;
-    struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-    stack_t          FatalConditionHandler::oldSigStack                                = {};
-    char             FatalConditionHandler::altStackMem[]                              = {};
+  FatalConditionHandler() {
+    isSet = true;
+    stack_t sigStack;
+    sigStack.ss_sp    = altStackMem;
+    sigStack.ss_size  = altStackSize;
+    sigStack.ss_flags = 0;
+    sigaltstack(&sigStack, &oldSigStack);
+    struct sigaction sa = {};
+    sa.sa_handler       = handleSignal;
+    sa.sa_flags         = SA_ONSTACK;
+    for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+      sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+    }
+  }
+
+  ~FatalConditionHandler() { reset(); }
+  static void reset() {
+    if(isSet) {
+      // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
+      for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+        sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
+      }
+      // Return the old stack
+      sigaltstack(&oldSigStack, nullptr);
+      isSet = false;
+    }
+  }
+};
+
+bool             FatalConditionHandler::isSet = false;
+struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
+stack_t          FatalConditionHandler::oldSigStack = {};
+size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
+char*            FatalConditionHandler::altStackMem = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
@@ -4064,179 +4806,173 @@ namespace {
 } // namespace
 
 namespace {
-    using namespace detail;
+using namespace detail;
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) ::OutputDebugStringA(text)
 #else
-    // TODO: integration with XCode and other IDEs
-#define DOCTEST_OUTPUT_DEBUG_STRING(text) // NOLINT(clang-diagnostic-unused-macros)
+// TODO: integration with XCode and other IDEs
+#define DOCTEST_OUTPUT_DEBUG_STRING(text)
 #endif // Platform
 
-    void addAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
-            g_cs->numAssertsCurrentTest_atomic++;
-    }
+void addAssert(assertType::Enum at) {
+  if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
+    g_cs->numAssertsCurrentTest_atomic++;
+}
 
-    void addFailedAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
-            g_cs->numAssertsFailedCurrentTest_atomic++;
-    }
+void addFailedAssert(assertType::Enum at) {
+  if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
+    g_cs->numAssertsFailedCurrentTest_atomic++;
+}
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message) {
-        g_cs->failure_flags |= TestCaseFailureReason::Crash;
+void reportFatal(const std::string& message) {
+  g_cs->failure_flags |= TestCaseFailureReason::Crash;
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
+  DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while(g_cs->subcasesStack.size()) {
-            g_cs->subcasesStack.pop_back();
-            DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
-        }
+  while (g_cs->subcaseStack.size()) {
+    g_cs->subcaseStack.pop_back();
+    DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+  }
 
-        g_cs->finalizeTestCaseData();
+  g_cs->finalizeTestCaseData();
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+  DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
 
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
-    }
+  DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+}
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 } // namespace
-namespace detail {
 
-    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type, const char* exception_string) {
-        m_test_case        = g_cs->currentTest;
-        m_at               = at;
-        m_file             = file;
-        m_line             = line;
-        m_expr             = expr;
-        m_failed           = true;
-        m_threw            = false;
-        m_threw_as         = false;
-        m_exception_type   = exception_type;
-        m_exception_string = exception_string;
+AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+                       const char* exception_type, const StringContains& exception_string)
+    : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
+      m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
+      m_exception_string(exception_string) {
 #if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
+  if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+    ++m_expr;
 #endif // MSVC
-    }
+}
 
-    void ResultBuilder::setResult(const Result& res) {
-        m_decomp = res.m_decomp;
-        m_failed = !res.m_passed;
-    }
+namespace detail {
+ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                             const char* exception_type, const String& exception_string)
+    : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
-    void ResultBuilder::translateException() {
-        m_threw     = true;
-        m_exception = translateActiveException();
-    }
+ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                             const char* exception_type, const Contains& exception_string)
+    : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
-    bool ResultBuilder::log() {
-        if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-            m_failed = !m_threw;
-        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
-            m_failed = !m_threw_as || (m_exception != m_exception_string);
-        } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-            m_failed = !m_threw_as;
-        } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            m_failed = m_exception != m_exception_string;
-        } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-            m_failed = m_threw;
-        }
+void ResultBuilder::setResult(const Result& res) {
+  m_decomp = res.m_decomp;
+  m_failed = !res.m_passed;
+}
 
-        if(m_exception.size())
-            m_exception = String("\"") + m_exception + "\"";
+void ResultBuilder::translateException() {
+  m_threw     = true;
+  m_exception = translateActiveException();
+}
 
-        if(is_running_in_test) {
-            addAssert(m_at);
-            DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
+bool ResultBuilder::log() {
+  if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+    m_failed = !m_threw;
+  } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+    m_failed = !m_threw_as || !m_exception_string.check(m_exception);
+  } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+    m_failed = !m_threw_as;
+  } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+    m_failed = !m_exception_string.check(m_exception);
+  } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+    m_failed = m_threw;
+  }
 
-            if(m_failed)
-                addFailedAssert(m_at);
-        } else if(m_failed) {
-            failed_out_of_a_testing_context(*this);
-        }
+  if(m_exception.size())
+    m_exception = "\"" + m_exception + "\"";
 
-        return m_failed && isDebuggerActive() &&
-               !getContextOptions()->no_breaks; // break into debugger
-    }
+  if(is_running_in_test) {
+    addAssert(m_at);
+    DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
 
-    void ResultBuilder::react() const {
-        if(m_failed && checkIfShouldThrow(m_at))
-            throwException();
-    }
+    if(m_failed)
+      addFailedAssert(m_at);
+  } else if(m_failed) {
+    failed_out_of_a_testing_context(*this);
+  }
 
-    void failed_out_of_a_testing_context(const AssertData& ad) {
-        if(g_cs->ah)
-            g_cs->ah(ad);
-        else
-            std::abort();
-    }
+  return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
+         (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
 
-    void decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
-                       Result result) {
-        bool failed = !result.m_passed;
+void ResultBuilder::react() const {
+  if(m_failed && checkIfShouldThrow(m_at))
+    throwException();
+}
 
-        // ###################################################################################
-        // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
-        // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
-        // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
-        DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
-    }
+void failed_out_of_a_testing_context(const AssertData& ad) {
+  if(g_cs->ah)
+    g_cs->ah(ad);
+  else
+    std::abort();
+}
 
-    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
-        m_stream   = getTlsOss();
-        m_file     = file;
-        m_line     = line;
-        m_severity = severity;
-    }
+bool decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
+                   const Result& result) {
+  bool failed = !result.m_passed;
 
-    IExceptionTranslator::IExceptionTranslator()  = default;
-    IExceptionTranslator::~IExceptionTranslator() = default;
+  // ###################################################################################
+  // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
+  // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
+  // ###################################################################################
+  DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
+  DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
+  return !failed;
+}
 
-    bool MessageBuilder::log() {
-        m_string = getTlsOssResult();
-        DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
+MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
+  m_stream   = tlssPush();
+  m_file     = file;
+  m_line     = line;
+  m_severity = severity;
+}
 
-        const bool isWarn = m_severity & assertType::is_warn;
+MessageBuilder::~MessageBuilder() {
+  if (!logged)
+    tlssPop();
+}
 
-        // warn is just a message in this context so we don't treat it as an assert
-        if(!isWarn) {
-            addAssert(m_severity);
-            addFailedAssert(m_severity);
-        }
+DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
-        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn; // break
-    }
+bool MessageBuilder::log() {
+  if (!logged) {
+    m_string = tlssPop();
+    logged = true;
+  }
 
-    void MessageBuilder::react() {
-        if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
-            throwException();
-    }
+  DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
 
-    MessageBuilder::~MessageBuilder() = default;
+  const bool isWarn = m_severity & assertType::is_warn;
+
+  // warn is just a message in this context so we don't treat it as an assert
+  if(!isWarn) {
+    addAssert(m_severity);
+    addFailedAssert(m_severity);
+  }
+
+  return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
+         (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
+}
+
+void MessageBuilder::react() {
+  if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
+    throwException();
+}
 } // namespace detail
 namespace {
-    using namespace detail;
+using namespace detail;
 
-    template <typename Ex>
-    [[noreturn]] void throw_exception(Ex const& e) {
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        std::cerr << "doctest will terminate because it needed to throw an exception.\n"
-                  << "The message was: " << e.what() << '\n';
-        std::terminate();
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
-
-#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
-    throw_exception(std::logic_error(                                                              \
-            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
-
-    // clang-format off
+// clang-format off
 
 // =================================================================================================
 // The following code has been taken verbatim from Catch2/include/internal/catch_xmlwriter.h/cpp
@@ -4265,8 +5001,8 @@ namespace {
         public:
             ScopedElement( XmlWriter* writer );
 
-            ScopedElement( ScopedElement&& other ) noexcept;
-            ScopedElement& operator=( ScopedElement&& other ) noexcept;
+            ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT;
+            ScopedElement& operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT;
 
             ~ScopedElement();
 
@@ -4317,9 +5053,9 @@ namespace {
 
         void ensureTagClosed();
 
-    private:
-
         void writeDeclaration();
+
+    private:
 
         void newlineIfNecessary();
 
@@ -4382,7 +5118,7 @@ namespace {
 
     void XmlEncode::encodeTo( std::ostream& os ) const {
         // Apostrophe escaping not necessary if we always use " to write attributes
-        // (see: http://www.w3.org/TR/xml/#syntax)
+        // (see: https://www.w3.org/TR/xml/#syntax)
 
         for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
             uchar c = m_str[idx];
@@ -4391,7 +5127,7 @@ namespace {
             case '&':   os << "&amp;"; break;
 
             case '>':
-                // See: http://www.w3.org/TR/xml/#syntax
+                // See: https://www.w3.org/TR/xml/#syntax
                 if (idx > 2 && m_str[idx - 1] == ']' && m_str[idx - 2] == ']')
                     os << "&gt;";
                 else
@@ -4409,7 +5145,7 @@ namespace {
                 // Check for control characters and invalid utf-8
 
                 // Escape control characters in standard ascii
-                // see http://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
+                // see https://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
                 if (c < 0x09 || (c > 0x0D && c < 0x20) || c == 0x7F) {
                     hexEscapeChar(os, c);
                     break;
@@ -4483,11 +5219,11 @@ namespace {
     :   m_writer( writer )
     {}
 
-    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
+    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT
     :   m_writer( other.m_writer ){
         other.m_writer = nullptr;
     }
-    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT {
         if ( m_writer ) {
             m_writer->endElement();
         }
@@ -4509,7 +5245,7 @@ namespace {
 
     XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
     {
-        writeDeclaration();
+        // writeDeclaration(); // called explicitly by the reporters that use the writer class - see issue #627
     }
 
     XmlWriter::~XmlWriter() {
@@ -4616,354 +5352,658 @@ namespace {
 // End of copy-pasted code from Catch
 // =================================================================================================
 
-    // clang-format on
+// clang-format on
 
-    struct XmlReporter : public IReporter
-    {
-        XmlWriter  xml;
-        std::mutex mutex;
+struct XmlReporter : public IReporter
+{
+  XmlWriter xml;
+  DOCTEST_DECLARE_MUTEX(mutex)
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc = nullptr;
+  // caching pointers/references to objects of these types - safe to do
+  const ContextOptions& opt;
+  const TestCaseData*   tc = nullptr;
 
-        XmlReporter(const ContextOptions& co)
-                : xml(*co.cout)
-                , opt(co) {}
+  XmlReporter(const ContextOptions& co)
+      : xml(*co.cout)
+        , opt(co) {}
 
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto              contexts = get_active_contexts();
-                std::stringstream ss;
-                for(int i = 0; i < num_contexts; ++i) {
-                    contexts[i]->stringify(&ss);
-                    xml.scopedElement("Info").writeText(ss.str());
-                    ss.str("");
-                }
-            }
-        }
+  void log_contexts() {
+    int num_contexts = get_num_active_contexts();
+    if(num_contexts) {
+      auto              contexts = get_active_contexts();
+      std::stringstream ss;
+      for(int i = 0; i < num_contexts; ++i) {
+        contexts[i]->stringify(&ss);
+        xml.scopedElement("Info").writeText(ss.str());
+        ss.str("");
+      }
+    }
+  }
 
-        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+  unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
 
-        void test_case_start_impl(const TestCaseData& in) {
-            bool open_ts_tag = false;
-            if(tc != nullptr) { // we have already opened a test suite
-                if(strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
-                    xml.endElement();
-                    open_ts_tag = true;
-                }
-            }
-            else {
-                open_ts_tag = true; // first test case ==> first test suite
-            }
-
-            if(open_ts_tag) {
-                xml.startElement("TestSuite");
-                xml.writeAttribute("name", in.m_test_suite);
-            }
-
-            tc = &in;
-            xml.startElement("TestCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file))
-                    .writeAttribute("line", line(in.m_line))
-                    .writeAttribute("description", in.m_description);
-
-            if(Approx(in.m_timeout) != 0)
-                xml.writeAttribute("timeout", in.m_timeout);
-            if(in.m_may_fail)
-                xml.writeAttribute("may_fail", true);
-            if(in.m_should_fail)
-                xml.writeAttribute("should_fail", true);
-        }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData& in) override {
-            test_run_start();
-            if(opt.list_reporters) {
-                for(auto& curr : getListeners())
-                    xml.scopedElement("Listener")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-                for(auto& curr : getReporters())
-                    xml.scopedElement("Reporter")
-                            .writeAttribute("priority", curr.first.first)
-                            .writeAttribute("name", curr.first.second);
-            } else if(opt.count || opt.list_test_cases) {
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]);
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-            } else if(opt.list_test_suites) {
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]);
-                xml.scopedElement("OverallResultsTestCases")
-                        .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
-                xml.scopedElement("OverallResultsTestSuites")
-                        .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
-            }
-            xml.endElement();
-        }
-
-        void test_run_start() override {
-            // remove .exe extension - mainly to have the same output on UNIX and Windows
-            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
-#ifdef DOCTEST_PLATFORM_WINDOWS
-            if(binary_name.rfind(".exe") != std::string::npos)
-                binary_name = binary_name.substr(0, binary_name.length() - 4);
-#endif // DOCTEST_PLATFORM_WINDOWS
-
-            xml.startElement("doctest").writeAttribute("binary", binary_name);
-            if(opt.no_version == false)
-                xml.writeAttribute("version", DOCTEST_VERSION_STR);
-
-            // only the consequential ones (TODO: filters)
-            xml.scopedElement("Options")
-                    .writeAttribute("order_by", opt.order_by.c_str())
-                    .writeAttribute("rand_seed", opt.rand_seed)
-                    .writeAttribute("first", opt.first)
-                    .writeAttribute("last", opt.last)
-                    .writeAttribute("abort_after", opt.abort_after)
-                    .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
-                    .writeAttribute("case_sensitive", opt.case_sensitive)
-                    .writeAttribute("no_throw", opt.no_throw)
-                    .writeAttribute("no_skip", opt.no_skip);
-        }
-
-        void test_run_end(const TestRunStats& p) override {
-            if(tc) // the TestSuite tag - only if there has been at least 1 test case
-                xml.endElement();
-
-            xml.scopedElement("OverallResultsAsserts")
-                    .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
-                    .writeAttribute("failures", p.numAssertsFailed);
-
-            xml.startElement("OverallResultsTestCases")
-                    .writeAttribute("successes",
-                                    p.numTestCasesPassingFilters - p.numTestCasesFailed)
-                    .writeAttribute("failures", p.numTestCasesFailed);
-            if(opt.no_skipped_summary == false)
-                xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
-            xml.endElement();
-
-            xml.endElement();
-        }
-
-        void test_case_start(const TestCaseData& in) override {
-            test_case_start_impl(in);
-            xml.ensureTagClosed();
-        }
-        
-        void test_case_reenter(const TestCaseData&) override {}
-
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            xml.startElement("OverallResultsAsserts")
-                    .writeAttribute("successes",
-                                    st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-                    .writeAttribute("failures", st.numAssertsFailedCurrentTest);
-            if(opt.duration)
-                xml.writeAttribute("duration", st.seconds);
-            if(tc->m_expected_failures)
-                xml.writeAttribute("expected_failures", tc->m_expected_failures);
-            xml.endElement();
-
-            xml.endElement();
-        }
-
-        void test_case_exception(const TestCaseException& e) override {
-            std::lock_guard<std::mutex> lock(mutex);
-
-            xml.scopedElement("Exception")
-                    .writeAttribute("crash", e.is_crash)
-                    .writeText(e.error_string.c_str());
-        }
-
-        void subcase_start(const SubcaseSignature& in) override {
-            std::lock_guard<std::mutex> lock(mutex);
-
-            xml.startElement("SubCase")
-                    .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file))
-                    .writeAttribute("line", line(in.m_line));
-            xml.ensureTagClosed();
-        }
-
-        void subcase_end() override { xml.endElement(); }
-
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt.success)
-                return;
-
-            std::lock_guard<std::mutex> lock(mutex);
-
-            xml.startElement("Expression")
-                    .writeAttribute("success", !rb.m_failed)
-                    .writeAttribute("type", assertString(rb.m_at))
-                    .writeAttribute("filename", skipPathFromFilename(rb.m_file))
-                    .writeAttribute("line", line(rb.m_line));
-
-            xml.scopedElement("Original").writeText(rb.m_expr);
-
-            if(rb.m_threw)
-                xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
-
-            if(rb.m_at & assertType::is_throws_as)
-                xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-            if(rb.m_at & assertType::is_throws_with)
-                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string);
-            if((rb.m_at & assertType::is_normal) && !rb.m_threw)
-                xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void log_message(const MessageData& mb) override {
-            std::lock_guard<std::mutex> lock(mutex);
-
-            xml.startElement("Message")
-                    .writeAttribute("type", failureString(mb.m_severity))
-                    .writeAttribute("filename", skipPathFromFilename(mb.m_file))
-                    .writeAttribute("line", line(mb.m_line));
-
-            xml.scopedElement("Text").writeText(mb.m_string.c_str());
-
-            log_contexts();
-
-            xml.endElement();
-        }
-
-        void test_case_skipped(const TestCaseData& in) override {
-            if(opt.no_skipped_summary == false) {
-                test_case_start_impl(in);
-                xml.writeAttribute("skipped", "true");
-                xml.endElement();
-            }
-        }
-    };
-
-    DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
-
-    struct Whitespace
-    {
-        int nrSpaces;
-        explicit Whitespace(int nr)
-                : nrSpaces(nr) {}
-    };
-
-    std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-        if(ws.nrSpaces != 0)
-            out << std::setw(ws.nrSpaces) << ' ';
-        return out;
+  void test_case_start_impl(const TestCaseData& in) {
+    bool open_ts_tag = false;
+    if(tc != nullptr) { // we have already opened a test suite
+      if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+        xml.endElement();
+        open_ts_tag = true;
+      }
+    }
+    else {
+      open_ts_tag = true; // first test case ==> first test suite
     }
 
-    struct ConsoleReporter : public IReporter
+    if(open_ts_tag) {
+      xml.startElement("TestSuite");
+      xml.writeAttribute("name", in.m_test_suite);
+    }
+
+    tc = &in;
+    xml.startElement("TestCase")
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
+        .writeAttribute("line", line(in.m_line))
+        .writeAttribute("description", in.m_description);
+
+    if(Approx(in.m_timeout) != 0)
+      xml.writeAttribute("timeout", in.m_timeout);
+    if(in.m_may_fail)
+      xml.writeAttribute("may_fail", true);
+    if(in.m_should_fail)
+      xml.writeAttribute("should_fail", true);
+  }
+
+  // =========================================================================================
+  // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+  // =========================================================================================
+
+  void report_query(const QueryData& in) override {
+    test_run_start();
+    if(opt.list_reporters) {
+      for(auto& curr : getListeners())
+        xml.scopedElement("Listener")
+            .writeAttribute("priority", curr.first.first)
+            .writeAttribute("name", curr.first.second);
+      for(auto& curr : getReporters())
+        xml.scopedElement("Reporter")
+            .writeAttribute("priority", curr.first.first)
+            .writeAttribute("name", curr.first.second);
+    } else if(opt.count || opt.list_test_cases) {
+      for(unsigned i = 0; i < in.num_data; ++i) {
+        xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+            .writeAttribute("testsuite", in.data[i]->m_test_suite)
+            .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
+            .writeAttribute("line", line(in.data[i]->m_line))
+            .writeAttribute("skipped", in.data[i]->m_skip);
+      }
+      xml.scopedElement("OverallResultsTestCases")
+          .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+    } else if(opt.list_test_suites) {
+      for(unsigned i = 0; i < in.num_data; ++i)
+        xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
+      xml.scopedElement("OverallResultsTestCases")
+          .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
+      xml.scopedElement("OverallResultsTestSuites")
+          .writeAttribute("unskipped", in.run_stats->numTestSuitesPassingFilters);
+    }
+    xml.endElement();
+  }
+
+  void test_run_start() override {
+    xml.writeDeclaration();
+
+    // remove .exe extension - mainly to have the same output on UNIX and Windows
+    std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if(binary_name.rfind(".exe") != std::string::npos)
+      binary_name = binary_name.substr(0, binary_name.length() - 4);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+    xml.startElement("doctest").writeAttribute("binary", binary_name);
+    if(opt.no_version == false)
+      xml.writeAttribute("version", DOCTEST_VERSION_STR);
+
+    // only the consequential ones (TODO: filters)
+    xml.scopedElement("Options")
+        .writeAttribute("order_by", opt.order_by.c_str())
+        .writeAttribute("rand_seed", opt.rand_seed)
+        .writeAttribute("first", opt.first)
+        .writeAttribute("last", opt.last)
+        .writeAttribute("abort_after", opt.abort_after)
+        .writeAttribute("subcase_filter_levels", opt.subcase_filter_levels)
+        .writeAttribute("case_sensitive", opt.case_sensitive)
+        .writeAttribute("no_throw", opt.no_throw)
+        .writeAttribute("no_skip", opt.no_skip);
+  }
+
+  void test_run_end(const TestRunStats& p) override {
+    if(tc) // the TestSuite tag - only if there has been at least 1 test case
+      xml.endElement();
+
+    xml.scopedElement("OverallResultsAsserts")
+        .writeAttribute("successes", p.numAsserts - p.numAssertsFailed)
+        .writeAttribute("failures", p.numAssertsFailed);
+
+    xml.startElement("OverallResultsTestCases")
+        .writeAttribute("successes",
+                        p.numTestCasesPassingFilters - p.numTestCasesFailed)
+        .writeAttribute("failures", p.numTestCasesFailed);
+    if(opt.no_skipped_summary == false)
+      xml.writeAttribute("skipped", p.numTestCases - p.numTestCasesPassingFilters);
+    xml.endElement();
+
+    xml.endElement();
+  }
+
+  void test_case_start(const TestCaseData& in) override {
+    test_case_start_impl(in);
+    xml.ensureTagClosed();
+  }
+
+  void test_case_reenter(const TestCaseData&) override {}
+
+  void test_case_end(const CurrentTestCaseStats& st) override {
+    xml.startElement("OverallResultsAsserts")
+        .writeAttribute("successes",
+                        st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
+        .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+        .writeAttribute("test_case_success", st.testCaseSuccess);
+    if(opt.duration)
+      xml.writeAttribute("duration", st.seconds);
+    if(tc->m_expected_failures)
+      xml.writeAttribute("expected_failures", tc->m_expected_failures);
+    xml.endElement();
+
+    xml.endElement();
+  }
+
+  void test_case_exception(const TestCaseException& e) override {
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.scopedElement("Exception")
+        .writeAttribute("crash", e.is_crash)
+        .writeText(e.error_string.c_str());
+  }
+
+  void subcase_start(const SubcaseSignature& in) override {
+    xml.startElement("SubCase")
+        .writeAttribute("name", in.m_name)
+        .writeAttribute("filename", skipPathFromFilename(in.m_file))
+        .writeAttribute("line", line(in.m_line));
+    xml.ensureTagClosed();
+  }
+
+  void subcase_end() override { xml.endElement(); }
+
+  void log_assert(const AssertData& rb) override {
+    if(!rb.m_failed && !opt.success)
+      return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.startElement("Expression")
+        .writeAttribute("success", !rb.m_failed)
+        .writeAttribute("type", assertString(rb.m_at))
+        .writeAttribute("filename", skipPathFromFilename(rb.m_file))
+        .writeAttribute("line", line(rb.m_line));
+
+    xml.scopedElement("Original").writeText(rb.m_expr);
+
+    if(rb.m_threw)
+      xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
+
+    if(rb.m_at & assertType::is_throws_as)
+      xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
+    if(rb.m_at & assertType::is_throws_with)
+      xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+    if((rb.m_at & assertType::is_normal) && !rb.m_threw)
+      xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
+
+    log_contexts();
+
+    xml.endElement();
+  }
+
+  void log_message(const MessageData& mb) override {
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    xml.startElement("Message")
+        .writeAttribute("type", failureString(mb.m_severity))
+        .writeAttribute("filename", skipPathFromFilename(mb.m_file))
+        .writeAttribute("line", line(mb.m_line));
+
+    xml.scopedElement("Text").writeText(mb.m_string.c_str());
+
+    log_contexts();
+
+    xml.endElement();
+  }
+
+  void test_case_skipped(const TestCaseData& in) override {
+    if(opt.no_skipped_summary == false) {
+      test_case_start_impl(in);
+      xml.writeAttribute("skipped", "true");
+      xml.endElement();
+    }
+  }
+};
+
+DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
+
+void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
+  if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
+      0) //!OCLINT bitwise operator in conditional
+    s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
+      << Color::None;
+
+  if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+    s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
+  } else if((rb.m_at & assertType::is_throws_as) &&
+             (rb.m_at & assertType::is_throws_with)) { //!OCLINT
+    s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+      << rb.m_exception_string.c_str()
+      << "\", " << rb.m_exception_type << " ) " << Color::None;
+    if(rb.m_threw) {
+      if(!rb.m_failed) {
+        s << "threw as expected!\n";
+      } else {
+        s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
+      }
+    } else {
+      s << "did NOT throw at all!\n";
+    }
+  } else if(rb.m_at &
+             assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+    s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
+      << rb.m_exception_type << " ) " << Color::None
+      << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
+                                      "threw a DIFFERENT exception: ") :
+                     "did NOT throw at all!")
+      << Color::Cyan << rb.m_exception << "\n";
+  } else if(rb.m_at &
+             assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+    s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+      << rb.m_exception_string.c_str()
+      << "\" ) " << Color::None
+      << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
+                                     "threw a DIFFERENT exception: ") :
+                     "did NOT throw at all!")
+      << Color::Cyan << rb.m_exception << "\n";
+  } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+    s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
+      << rb.m_exception << "\n";
+  } else {
+    s << (rb.m_threw ? "THREW exception: " :
+                     (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+    if(rb.m_threw)
+      s << rb.m_exception << "\n";
+    else
+      s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
+  }
+}
+
+// TODO:
+// - log_message()
+// - respond to queries
+// - honor remaining options
+// - more attributes in tags
+struct JUnitReporter : public IReporter
+{
+  XmlWriter xml;
+  DOCTEST_DECLARE_MUTEX(mutex)
+  Timer timer;
+  std::vector<String> deepestSubcaseStackNames;
+
+  struct JUnitTestCaseData
+  {
+    static std::string getCurrentTimestamp() {
+      // Beware, this is not reentrant because of backward compatibility issues
+      // Also, UTC only, again because of backward compatibility (%z is C++11)
+      time_t rawtime;
+      std::time(&rawtime);
+      auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+
+      std::tm timeInfo;
+#ifdef DOCTEST_PLATFORM_WINDOWS
+      gmtime_s(&timeInfo, &rawtime);
+#else // DOCTEST_PLATFORM_WINDOWS
+      gmtime_r(&rawtime, &timeInfo);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+      char timeStamp[timeStampSize];
+      const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+
+      std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+      return std::string(timeStamp);
+    }
+
+    struct JUnitTestMessage
     {
-        std::ostream&                 s;
-        bool                          hasLoggedCurrentTestStart;
-        std::vector<SubcaseSignature> subcasesStack;
-        std::mutex                    mutex;
+      JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
+          : message(_message), type(_type), details(_details) {}
 
-        // caching pointers/references to objects of these types - safe to do
-        const ContextOptions& opt;
-        const TestCaseData*   tc;
+      JUnitTestMessage(const std::string& _message, const std::string& _details)
+          : message(_message), type(), details(_details) {}
 
-        ConsoleReporter(const ContextOptions& co)
-                : s(*co.cout)
-                , opt(co) {}
+      std::string message, type, details;
+    };
 
-        ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
-                : s(ostr)
-                , opt(co) {}
+    struct JUnitTestCase
+    {
+      JUnitTestCase(const std::string& _classname, const std::string& _name)
+          : classname(_classname), name(_name), time(0), failures() {}
 
-        // =========================================================================================
-        // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
-        // =========================================================================================
+      std::string classname, name;
+      double time;
+      std::vector<JUnitTestMessage> failures, errors;
+    };
 
-        void separator_to_stream() {
-            s << Color::Yellow
-              << "==============================================================================="
-                 "\n";
-        }
+    void add(const std::string& classname, const std::string& name) {
+      testcases.emplace_back(classname, name);
+    }
 
-        const char* getSuccessOrFailString(bool success, assertType::Enum at,
-                                           const char* success_str) {
-            if(success)
-                return success_str;
-            return failureString(at);
-        }
+    void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
+      for(auto& curr: nameStack)
+        if(curr.size())
+          testcases.back().name += std::string("/") + curr.c_str();
+    }
 
-        Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
-            return success ? Color::BrightGreen :
-                             (at & assertType::is_warn) ? Color::Yellow : Color::Red;
-        }
+    void addTime(double time) {
+      if(time < 1e-4)
+        time = 0;
+      testcases.back().time = time;
+      totalSeconds += time;
+    }
 
-        void successOrFailColoredStringToStream(bool success, assertType::Enum at,
-                                                const char* success_str = "SUCCESS") {
-            s << getSuccessOrFailColor(success, at)
-              << getSuccessOrFailString(success, at, success_str) << ": ";
-        }
+    void addFailure(const std::string& message, const std::string& type, const std::string& details) {
+      testcases.back().failures.emplace_back(message, type, details);
+      ++totalFailures;
+    }
 
-        void log_contexts() {
-            int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
-                auto contexts = get_active_contexts();
+    void addError(const std::string& message, const std::string& details) {
+      testcases.back().errors.emplace_back(message, details);
+      ++totalErrors;
+    }
 
-                s << Color::None << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
-                    s << (i == 0 ? "" : "          ");
-                    contexts[i]->stringify(&s);
-                    s << "\n";
-                }
-            }
+    std::vector<JUnitTestCase> testcases;
+    double totalSeconds = 0;
+    int totalErrors = 0, totalFailures = 0;
+  };
 
-            s << "\n";
-        }
+  JUnitTestCaseData testCaseData;
 
-        void logTestStart() {
-            if(hasLoggedCurrentTestStart)
-                return;
+  // caching pointers/references to objects of these types - safe to do
+  const ContextOptions& opt;
+  const TestCaseData*   tc = nullptr;
 
-            separator_to_stream();
-            file_line_to_stream(s, tc->m_file, tc->m_line, "\n");
-            if(tc->m_description)
-                s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-            if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
-                s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-            if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-                s << Color::None << "TEST CASE:  ";
-            s << Color::None << tc->m_name << "\n";
+  JUnitReporter(const ContextOptions& co)
+      : xml(*co.cout)
+        , opt(co) {}
 
-            for(auto& curr : subcasesStack)
-                if(curr.m_name[0] != '\0')
-                    s << "  " << curr.m_name << "\n";
+  unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
 
-            s << "\n";
+  // =========================================================================================
+  // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+  // =========================================================================================
 
-            hasLoggedCurrentTestStart = true;
-        }
+  void report_query(const QueryData&) override {
+    xml.writeDeclaration();
+  }
 
-        void printVersion() {
-            if(opt.no_version == false)
-                s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-                  << DOCTEST_VERSION_STR << "\"\n";
-        }
+  void test_run_start() override {
+    xml.writeDeclaration();
+  }
 
-        void printIntro() {
-            printVersion();
-            s << Color::Cyan << "[doctest] " << Color::None
-              << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
-        }
+  void test_run_end(const TestRunStats& p) override {
+    // remove .exe extension - mainly to have the same output on UNIX and Windows
+    std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+#ifdef DOCTEST_PLATFORM_WINDOWS
+    if(binary_name.rfind(".exe") != std::string::npos)
+      binary_name = binary_name.substr(0, binary_name.length() - 4);
+#endif // DOCTEST_PLATFORM_WINDOWS
+    xml.startElement("testsuites");
+    xml.startElement("testsuite").writeAttribute("name", binary_name)
+        .writeAttribute("errors", testCaseData.totalErrors)
+        .writeAttribute("failures", testCaseData.totalFailures)
+        .writeAttribute("tests", p.numAsserts);
+    if(opt.no_time_in_output == false) {
+      xml.writeAttribute("time", testCaseData.totalSeconds);
+      xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
+    }
+    if(opt.no_version == false)
+      xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
 
-        void printHelp() {
-            int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
-            printVersion();
-            // clang-format off
+    for(const auto& testCase : testCaseData.testcases) {
+      xml.startElement("testcase")
+          .writeAttribute("classname", testCase.classname)
+          .writeAttribute("name", testCase.name);
+      if(opt.no_time_in_output == false)
+        xml.writeAttribute("time", testCase.time);
+      // This is not ideal, but it should be enough to mimic gtest's junit output.
+      xml.writeAttribute("status", "run");
+
+      for(const auto& failure : testCase.failures) {
+        xml.scopedElement("failure")
+            .writeAttribute("message", failure.message)
+            .writeAttribute("type", failure.type)
+            .writeText(failure.details, false);
+      }
+
+      for(const auto& error : testCase.errors) {
+        xml.scopedElement("error")
+            .writeAttribute("message", error.message)
+            .writeText(error.details);
+      }
+
+      xml.endElement();
+    }
+    xml.endElement();
+    xml.endElement();
+  }
+
+  void test_case_start(const TestCaseData& in) override {
+    testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+    timer.start();
+  }
+
+  void test_case_reenter(const TestCaseData& in) override {
+    testCaseData.addTime(timer.getElapsedSeconds());
+    testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+    deepestSubcaseStackNames.clear();
+
+    timer.start();
+    testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+  }
+
+  void test_case_end(const CurrentTestCaseStats&) override {
+    testCaseData.addTime(timer.getElapsedSeconds());
+    testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+    deepestSubcaseStackNames.clear();
+  }
+
+  void test_case_exception(const TestCaseException& e) override {
+    DOCTEST_LOCK_MUTEX(mutex)
+    testCaseData.addError("exception", e.error_string.c_str());
+  }
+
+  void subcase_start(const SubcaseSignature& in) override {
+    deepestSubcaseStackNames.push_back(in.m_name);
+  }
+
+  void subcase_end() override {}
+
+  void log_assert(const AssertData& rb) override {
+    if(!rb.m_failed) // report only failures & ignore the `success` option
+      return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    std::ostringstream os;
+    os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
+       << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+
+    fulltext_log_assert_to_stream(os, rb);
+    log_contexts(os);
+    testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
+  }
+
+  void log_message(const MessageData&) override {}
+
+  void test_case_skipped(const TestCaseData&) override {}
+
+  void log_contexts(std::ostringstream& s) {
+    int num_contexts = get_num_active_contexts();
+    if(num_contexts) {
+      auto contexts = get_active_contexts();
+
+      s << "  logged: ";
+      for(int i = 0; i < num_contexts; ++i) {
+        s << (i == 0 ? "" : "          ");
+        contexts[i]->stringify(&s);
+        s << std::endl;
+      }
+    }
+  }
+};
+
+DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+
+struct Whitespace
+{
+  int nrSpaces;
+  explicit Whitespace(int nr)
+      : nrSpaces(nr) {}
+};
+
+std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
+  if(ws.nrSpaces != 0)
+    out << std::setw(ws.nrSpaces) << ' ';
+  return out;
+}
+
+struct ConsoleReporter : public IReporter
+{
+  std::ostream&                 s;
+  bool                          hasLoggedCurrentTestStart;
+  std::vector<SubcaseSignature> subcasesStack;
+  size_t                        currentSubcaseLevel;
+  DOCTEST_DECLARE_MUTEX(mutex)
+
+  // caching pointers/references to objects of these types - safe to do
+  const ContextOptions& opt;
+  const TestCaseData*   tc;
+
+  ConsoleReporter(const ContextOptions& co)
+      : s(*co.cout)
+        , opt(co) {}
+
+  ConsoleReporter(const ContextOptions& co, std::ostream& ostr)
+      : s(ostr)
+        , opt(co) {}
+
+  // =========================================================================================
+  // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
+  // =========================================================================================
+
+  void separator_to_stream() {
+    s << Color::Yellow
+      << "==============================================================================="
+         "\n";
+  }
+
+  const char* getSuccessOrFailString(bool success, assertType::Enum at,
+                                     const char* success_str) {
+    if(success)
+      return success_str;
+    return failureString(at);
+  }
+
+  Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
+    return success ? Color::BrightGreen :
+           (at & assertType::is_warn) ? Color::Yellow : Color::Red;
+  }
+
+  void successOrFailColoredStringToStream(bool success, assertType::Enum at,
+                                          const char* success_str = "SUCCESS") {
+    s << getSuccessOrFailColor(success, at)
+      << getSuccessOrFailString(success, at, success_str) << ": ";
+  }
+
+  void log_contexts() {
+    int num_contexts = get_num_active_contexts();
+    if(num_contexts) {
+      auto contexts = get_active_contexts();
+
+      s << Color::None << "  logged: ";
+      for(int i = 0; i < num_contexts; ++i) {
+        s << (i == 0 ? "" : "          ");
+        contexts[i]->stringify(&s);
+        s << "\n";
+      }
+    }
+
+    s << "\n";
+  }
+
+  // this was requested to be made virtual so users could override it
+  virtual void file_line_to_stream(const char* file, int line,
+                                   const char* tail = "") {
+    s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+      << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+      << (opt.gnu_file_line ? ":" : "):") << tail;
+  }
+
+  void logTestStart() {
+    if(hasLoggedCurrentTestStart)
+      return;
+
+    separator_to_stream();
+    file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
+    if(tc->m_description)
+      s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
+    if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+      s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+    if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+      s << Color::Yellow << "TEST CASE:  ";
+    s << Color::None << tc->m_name << "\n";
+
+    for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+      if(subcasesStack[i].m_name[0] != '\0')
+        s << "  " << subcasesStack[i].m_name << "\n";
+    }
+
+    if(currentSubcaseLevel != subcasesStack.size()) {
+      s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
+      for(size_t i = 0; i < subcasesStack.size(); ++i) {
+        if(subcasesStack[i].m_name[0] != '\0')
+          s << "  " << subcasesStack[i].m_name << "\n";
+      }
+    }
+
+    s << "\n";
+
+    hasLoggedCurrentTestStart = true;
+  }
+
+  void printVersion() {
+    if(opt.no_version == false)
+      s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
+        << DOCTEST_VERSION_STR << "\"\n";
+  }
+
+  void printIntro() {
+    if(opt.no_intro == false) {
+      printVersion();
+      s << Color::Cyan << "[doctest] " << Color::None
+        << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+    }
+  }
+
+  void printHelp() {
+    int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
+    printVersion();
+    // clang-format off
             s << Color::Cyan << "[doctest]\n" << Color::None;
             s << Color::Cyan << "[doctest] " << Color::None;
             s << "boolean values: \"1/on/yes/true\" or \"0/off/no/false\"\n";
@@ -5019,7 +6059,7 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "output filename\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
               << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
-            s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - by [file/suite/name/rand]\n";
+            s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
               << Whitespace(sizePrefixDisplay*1) << "seed for random ordering\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "f,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "first=<int>                   "
@@ -5042,12 +6082,18 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "exits after the tests finish\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "d,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "duration=<bool>               "
               << Whitespace(sizePrefixDisplay*1) << "prints the time duration of each test\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "m,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "minimal=<bool>                "
+              << Whitespace(sizePrefixDisplay*1) << "minimal console output (only failures)\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "q,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "quiet=<bool>                  "
+              << Whitespace(sizePrefixDisplay*1) << "no console output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nt,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-throw=<bool>               "
               << Whitespace(sizePrefixDisplay*1) << "skips exceptions-related assert checks\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ne,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-exitcode=<bool>            "
               << Whitespace(sizePrefixDisplay*1) << "returns (or exits) always with success\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-run=<bool>                 "
               << Whitespace(sizePrefixDisplay*1) << "skips all runtime doctest operations\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ni,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-intro=<bool>               "
+              << Whitespace(sizePrefixDisplay*1) << "omit the framework intro in the output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nv,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-version=<bool>             "
               << Whitespace(sizePrefixDisplay*1) << "omit the framework version in the output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-colors=<bool>              "
@@ -5065,445 +6111,433 @@ namespace {
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nln, --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-line-numbers=<bool>        "
               << Whitespace(sizePrefixDisplay*1) << "0 instead of real line numbers in output\n";
             // ================================================================================== << 79
-            // clang-format on
+    // clang-format on
 
-            s << Color::Cyan << "\n[doctest] " << Color::None;
-            s << "for more information visit the project documentation\n\n";
-        }
+    s << Color::Cyan << "\n[doctest] " << Color::None;
+    s << "for more information visit the project documentation\n\n";
+  }
 
-        void printRegisteredReporters() {
-            printVersion();
-            auto printReporters = [this] (const reporterMap& reporters, const char* type) {
-                if(reporters.size()) {
-                    s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
-                    for(auto& curr : reporters)
-                        s << "priority: " << std::setw(5) << curr.first.first
-                          << " name: " << curr.first.second << "\n";
-                }
-            };
-            printReporters(getListeners(), "listeners");
-            printReporters(getReporters(), "reporters");
-        }
-
-        void list_query_results() {
-            separator_to_stream();
-            if(opt.count || opt.list_test_cases) {
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-            } else if(opt.list_test_suites) {
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "test suites with unskipped test cases passing the current filters: "
-                  << g_cs->numTestSuitesPassingFilters << "\n";
-            }
-        }
-
-        // =========================================================================================
-        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
-        // =========================================================================================
-
-        void report_query(const QueryData& in) override {
-            if(opt.version) {
-                printVersion();
-            } else if(opt.help) {
-                printHelp();
-            } else if(opt.list_reporters) {
-                printRegisteredReporters();
-            } else if(opt.count || opt.list_test_cases) {
-                if(opt.list_test_cases) {
-                    s << Color::Cyan << "[doctest] " << Color::None
-                      << "listing all test case names\n";
-                    separator_to_stream();
-                }
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i] << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-
-            } else if(opt.list_test_suites) {
-                s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
-                separator_to_stream();
-
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i] << "\n";
-
-                separator_to_stream();
-
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "test suites with unskipped test cases passing the current filters: "
-                  << g_cs->numTestSuitesPassingFilters << "\n";
-            }
-        }
-
-        void test_run_start() override { printIntro(); }
-
-        void test_run_end(const TestRunStats& p) override {
-            separator_to_stream();
-
-            const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(6)
-              << p.numTestCasesPassingFilters << " | "
-              << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                          Color::Green)
-              << std::setw(6) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-              << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(6) << p.numTestCasesFailed << " failed" << Color::None << " | ";
-            if(opt.no_skipped_summary == false) {
-                const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped
-                  << " skipped" << Color::None;
-            }
-            s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6)
-              << p.numAsserts << " | "
-              << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(6) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
-              << p.numAssertsFailed << " failed" << Color::None << " |\n";
-            s << Color::Cyan << "[doctest] " << Color::None
-              << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
-              << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
-        }
-
-        void test_case_start(const TestCaseData& in) override {
-            hasLoggedCurrentTestStart = false;
-            tc                        = &in;
-        }
-        
-        void test_case_reenter(const TestCaseData&) override {}
-
-        void test_case_end(const CurrentTestCaseStats& st) override {
-            // log the preamble of the test case only if there is something
-            // else to print - something other than that an assert has failed
-            if(opt.duration ||
-               (st.failure_flags && st.failure_flags != TestCaseFailureReason::AssertFailure))
-                logTestStart();
-
-            if(opt.duration)
-                s << Color::None << std::setprecision(6) << std::fixed << st.seconds
-                  << " s: " << tc->m_name << "\n";
-
-            if(st.failure_flags & TestCaseFailureReason::Timeout)
-                s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-                  << std::fixed << tc->m_timeout << "!\n";
-
-            if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
-                s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
-                s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
-                s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
-                s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
-                  << " times so marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
-                s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
-                  << " times as expected so marking it as not failed!\n";
-            }
-            if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
-                s << Color::Red << "Aborting - too many failed asserts!\n";
-            }
-            s << Color::None; // lgtm [cpp/useless-expression]
-        }
-
-        void test_case_exception(const TestCaseException& e) override {
-            logTestStart();
-
-            file_line_to_stream(s, tc->m_file, tc->m_line, " ");
-            successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
-                                                                   assertType::is_check);
-            s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
-              << Color::Cyan << e.error_string << "\n";
-
-            int num_stringified_contexts = get_num_stringified_contexts();
-            if(num_stringified_contexts) {
-                auto stringified_contexts = get_stringified_contexts();
-                s << Color::None << "  logged: ";
-                for(int i = num_stringified_contexts; i > 0; --i) {
-                    s << (i == num_stringified_contexts ? "" : "          ")
-                      << stringified_contexts[i - 1] << "\n";
-                }
-            }
-            s << "\n" << Color::None;
-        }
-
-        void subcase_start(const SubcaseSignature& subc) override {
-            std::lock_guard<std::mutex> lock(mutex);
-            subcasesStack.push_back(subc);
-            hasLoggedCurrentTestStart = false;
-        }
-
-        void subcase_end() override {
-            std::lock_guard<std::mutex> lock(mutex);
-            subcasesStack.pop_back();
-            hasLoggedCurrentTestStart = false;
-        }
-
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt.success)
-                return;
-
-            std::lock_guard<std::mutex> lock(mutex);
-
-            logTestStart();
-
-            file_line_to_stream(s, rb.m_file, rb.m_line, " ");
-            successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
-            if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-               0) //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-                  << Color::None;
-
-            if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-                s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-            } else if((rb.m_at & assertType::is_throws_as) &&
-                      (rb.m_at & assertType::is_throws_with)) { //!OCLINT
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                  << rb.m_exception_string << "\", " << rb.m_exception_type << " ) " << Color::None;
-                if(rb.m_threw) {
-                    if(!rb.m_failed) {
-                        s << "threw as expected!\n";
-                    } else {
-                        s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
-                    }
-                } else {
-                    s << "did NOT throw at all!\n";
-                }
-            } else if(rb.m_at &
-                      assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-                  << rb.m_exception_type << " ) " << Color::None
-                  << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                                    "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
-                  << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at &
-                      assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                  << rb.m_exception_string << "\" ) " << Color::None
-                  << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                                   "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
-                  << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-                s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-                  << rb.m_exception << "\n";
-            } else {
-                s << (rb.m_threw ? "THREW exception: " :
-                                   (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-                if(rb.m_threw)
-                    s << rb.m_exception << "\n";
-                else
-                    s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
-            }
-
-            log_contexts();
-        }
-
-        void log_message(const MessageData& mb) override {
-            std::lock_guard<std::mutex> lock(mutex);
-
-            logTestStart();
-
-            file_line_to_stream(s, mb.m_file, mb.m_line, " ");
-            s << getSuccessOrFailColor(false, mb.m_severity)
-              << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE") << ": ";
-            s << Color::None << mb.m_string << "\n";
-            log_contexts();
-        }
-
-        void test_case_skipped(const TestCaseData&) override {}
+  void printRegisteredReporters() {
+    printVersion();
+    auto printReporters = [this] (const reporterMap& reporters, const char* type) {
+      if(reporters.size()) {
+        s << Color::Cyan << "[doctest] " << Color::None << "listing all registered " << type << "\n";
+        for(auto& curr : reporters)
+          s << "priority: " << std::setw(5) << curr.first.first
+            << " name: " << curr.first.second << "\n";
+      }
     };
+    printReporters(getListeners(), "listeners");
+    printReporters(getReporters(), "reporters");
+  }
 
-    DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
+  // =========================================================================================
+  // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+  // =========================================================================================
+
+  void report_query(const QueryData& in) override {
+    if(opt.version) {
+      printVersion();
+    } else if(opt.help) {
+      printHelp();
+    } else if(opt.list_reporters) {
+      printRegisteredReporters();
+    } else if(opt.count || opt.list_test_cases) {
+      if(opt.list_test_cases) {
+        s << Color::Cyan << "[doctest] " << Color::None
+          << "listing all test case names\n";
+        separator_to_stream();
+      }
+
+      for(unsigned i = 0; i < in.num_data; ++i)
+        s << Color::None << in.data[i]->m_name << "\n";
+
+      separator_to_stream();
+
+      s << Color::Cyan << "[doctest] " << Color::None
+        << "unskipped test cases passing the current filters: "
+        << g_cs->numTestCasesPassingFilters << "\n";
+
+    } else if(opt.list_test_suites) {
+      s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
+      separator_to_stream();
+
+      for(unsigned i = 0; i < in.num_data; ++i)
+        s << Color::None << in.data[i]->m_test_suite << "\n";
+
+      separator_to_stream();
+
+      s << Color::Cyan << "[doctest] " << Color::None
+        << "unskipped test cases passing the current filters: "
+        << g_cs->numTestCasesPassingFilters << "\n";
+      s << Color::Cyan << "[doctest] " << Color::None
+        << "test suites with unskipped test cases passing the current filters: "
+        << g_cs->numTestSuitesPassingFilters << "\n";
+    }
+  }
+
+  void test_run_start() override {
+    if(!opt.minimal)
+      printIntro();
+  }
+
+  void test_run_end(const TestRunStats& p) override {
+    if(opt.minimal && p.numTestCasesFailed == 0)
+      return;
+
+    separator_to_stream();
+    s << std::dec;
+
+    auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+    auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+    auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
+    const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+    s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
+      << p.numTestCasesPassingFilters << " | "
+      << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
+                                                                Color::Green)
+      << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
+      << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
+      << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
+    if(opt.no_skipped_summary == false) {
+      const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
+      s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
+        << " skipped" << Color::None;
+    }
+    s << "\n";
+    s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
+      << p.numAsserts << " | "
+      << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+      << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+      << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
+      << p.numAssertsFailed << " failed" << Color::None << " |\n";
+    s << Color::Cyan << "[doctest] " << Color::None
+      << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
+      << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+  }
+
+  void test_case_start(const TestCaseData& in) override {
+    hasLoggedCurrentTestStart = false;
+    tc                        = &in;
+    subcasesStack.clear();
+    currentSubcaseLevel = 0;
+  }
+
+  void test_case_reenter(const TestCaseData&) override {
+    subcasesStack.clear();
+  }
+
+  void test_case_end(const CurrentTestCaseStats& st) override {
+    if(tc->m_no_output)
+      return;
+
+    // log the preamble of the test case only if there is something
+    // else to print - something other than that an assert has failed
+    if(opt.duration ||
+        (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
+      logTestStart();
+
+    if(opt.duration)
+      s << Color::None << std::setprecision(6) << std::fixed << st.seconds
+        << " s: " << tc->m_name << "\n";
+
+    if(st.failure_flags & TestCaseFailureReason::Timeout)
+      s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
+        << std::fixed << tc->m_timeout << "!\n";
+
+    if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+      s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
+    } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+      s << Color::Yellow << "Failed as expected so marking it as not failed\n";
+    } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+      s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
+    } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+      s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
+        << " times so marking it as failed!\n";
+    } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+      s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
+        << " times as expected so marking it as not failed!\n";
+    }
+    if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+      s << Color::Red << "Aborting - too many failed asserts!\n";
+    }
+    s << Color::None; // lgtm [cpp/useless-expression]
+  }
+
+  void test_case_exception(const TestCaseException& e) override {
+    DOCTEST_LOCK_MUTEX(mutex)
+    if(tc->m_no_output)
+      return;
+
+    logTestStart();
+
+    file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
+    successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
+                                                         assertType::is_check);
+    s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
+      << Color::Cyan << e.error_string << "\n";
+
+    int num_stringified_contexts = get_num_stringified_contexts();
+    if(num_stringified_contexts) {
+      auto stringified_contexts = get_stringified_contexts();
+      s << Color::None << "  logged: ";
+      for(int i = num_stringified_contexts; i > 0; --i) {
+        s << (i == num_stringified_contexts ? "" : "          ")
+          << stringified_contexts[i - 1] << "\n";
+      }
+    }
+    s << "\n" << Color::None;
+  }
+
+  void subcase_start(const SubcaseSignature& subc) override {
+    subcasesStack.push_back(subc);
+    ++currentSubcaseLevel;
+    hasLoggedCurrentTestStart = false;
+  }
+
+  void subcase_end() override {
+    --currentSubcaseLevel;
+    hasLoggedCurrentTestStart = false;
+  }
+
+  void log_assert(const AssertData& rb) override {
+    if((!rb.m_failed && !opt.success) || tc->m_no_output)
+      return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    logTestStart();
+
+    file_line_to_stream(rb.m_file, rb.m_line, " ");
+    successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
+
+    fulltext_log_assert_to_stream(s, rb);
+
+    log_contexts();
+  }
+
+  void log_message(const MessageData& mb) override {
+    if(tc->m_no_output)
+      return;
+
+    DOCTEST_LOCK_MUTEX(mutex)
+
+    logTestStart();
+
+    file_line_to_stream(mb.m_file, mb.m_line, " ");
+    s << getSuccessOrFailColor(false, mb.m_severity)
+      << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
+                                "MESSAGE") << ": ";
+    s << Color::None << mb.m_string << "\n";
+    log_contexts();
+  }
+
+  void test_case_skipped(const TestCaseData&) override {}
+};
+
+DOCTEST_REGISTER_REPORTER("console", 0, ConsoleReporter);
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    struct DebugOutputWindowReporter : public ConsoleReporter
-    {
-        DOCTEST_THREAD_LOCAL static std::ostringstream oss;
+struct DebugOutputWindowReporter : public ConsoleReporter
+{
+  DOCTEST_THREAD_LOCAL static std::ostringstream oss;
 
-        DebugOutputWindowReporter(const ContextOptions& co)
-                : ConsoleReporter(co, oss) {}
+  DebugOutputWindowReporter(const ContextOptions& co)
+      : ConsoleReporter(co, oss) {}
 
 #define DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(func, type, arg)                                    \
     void func(type arg) override {                                                                 \
         bool with_col = g_no_colors;                                                               \
         g_no_colors   = false;                                                                     \
         ConsoleReporter::func(arg);                                                                \
-        DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                            \
-        oss.str("");                                                                               \
+        if(oss.tellp() != std::streampos{}) {                                                      \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
+            oss.str("");                                                                           \
+        }                                                                                          \
         g_no_colors = with_col;                                                                    \
     }
 
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_end, DOCTEST_EMPTY, DOCTEST_EMPTY)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData&, in)
-        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData&, in)
-    };
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_end, DOCTEST_EMPTY, DOCTEST_EMPTY)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_assert, const AssertData&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(log_message, const MessageData&, in)
+  DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_skipped, const TestCaseData&, in)
+};
 
-    DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
+DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-    // the implementation of parseOption()
-    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String* value) {
-        // going from the end to the beginning and stopping on the first occurrence from the end
-        for(int i = argc; i > 0; --i) {
-            auto index = i - 1;
-            auto temp = std::strstr(argv[index], pattern);
-            if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
-                // eliminate matches in which the chars before the option are not '-'
-                bool noBadCharsFound = true;
-                auto curr            = argv[index];
-                while(curr != temp) {
-                    if(*curr++ != '-') {
-                        noBadCharsFound = false;
-                        break;
-                    }
-                }
-                if(noBadCharsFound && argv[index][0] == '-') {
-                    if(value) {
-                        // parsing the value of an option
-                        temp += strlen(pattern);
-                        const unsigned len = strlen(temp);
-                        if(len) {
-                            *value = temp;
-                            return true;
-                        }
-                    } else {
-                        // just a flag - no value
-                        return true;
-                    }
-                }
-            }
+// the implementation of parseOption()
+bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String* value) {
+  // going from the end to the beginning and stopping on the first occurrence from the end
+  for(int i = argc; i > 0; --i) {
+    auto index = i - 1;
+    auto temp = std::strstr(argv[index], pattern);
+    if(temp && (value || strlen(temp) == strlen(pattern))) { //!OCLINT prefer early exits and continue
+      // eliminate matches in which the chars before the option are not '-'
+      bool noBadCharsFound = true;
+      auto curr            = argv[index];
+      while(curr != temp) {
+        if(*curr++ != '-') {
+          noBadCharsFound = false;
+          break;
         }
-        return false;
+      }
+      if(noBadCharsFound && argv[index][0] == '-') {
+        if(value) {
+          // parsing the value of an option
+          temp += strlen(pattern);
+          const unsigned len = strlen(temp);
+          if(len) {
+            *value = temp;
+            return true;
+          }
+        } else {
+          // just a flag - no value
+          return true;
+        }
+      }
     }
+  }
+  return false;
+}
 
-    // parses an option and returns the string after the '=' character
-    bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
-                     const String& defaultVal = String()) {
-        if(value)
-            *value = defaultVal;
+// parses an option and returns the string after the '=' character
+bool parseOption(int argc, const char* const* argv, const char* pattern, String* value = nullptr,
+                 const String& defaultVal = String()) {
+  if(value)
+    *value = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        // offset (normally 3 for "dt-") to skip prefix
-        if(parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
-            return true;
+  // offset (normally 3 for "dt-") to skip prefix
+  if(parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), value))
+    return true;
 #endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
-        return parseOptionImpl(argc, argv, pattern, value);
-    }
+  return parseOptionImpl(argc, argv, pattern, value);
+}
 
-    // locates a flag on the command line
-    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
-        return parseOption(argc, argv, pattern);
-    }
+// locates a flag on the command line
+bool parseFlag(int argc, const char* const* argv, const char* pattern) {
+  return parseOption(argc, argv, pattern);
+}
 
-    // parses a comma separated list of words after a pattern in one of the arguments in argv
-    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
-                           std::vector<String>& res) {
-        String filtersString;
-        if(parseOption(argc, argv, pattern, &filtersString)) {
-            // tokenize with "," as a separator
-            // cppcheck-suppress strtokCalled
-            DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-            auto pch = std::strtok(filtersString.c_str(), ","); // modifies the string
-            while(pch != nullptr) {
-                if(strlen(pch))
-                    res.push_back(pch);
-                // uses the strtok() internal state to go to the next token
-                // cppcheck-suppress strtokCalled
-                pch = std::strtok(nullptr, ",");
-            }
-            DOCTEST_CLANG_SUPPRESS_WARNING_POP
-            return true;
-        }
-        return false;
-    }
-
-    enum optionType
-    {
-        option_bool,
-        option_int
+// parses a comma separated list of words after a pattern in one of the arguments in argv
+bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
+                       std::vector<String>& res) {
+  String filtersString;
+  if(parseOption(argc, argv, pattern, &filtersString)) {
+    // tokenize with "," as a separator, unless escaped with backslash
+    std::ostringstream s;
+    auto flush = [&s, &res]() {
+      auto string = s.str();
+      if(string.size() > 0) {
+        res.push_back(string.c_str());
+      }
+      s.str("");
     };
 
-    // parses an int/bool option from the command line
-    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
-                        int& res) {
-        String parsedValue;
-        if(!parseOption(argc, argv, pattern, &parsedValue))
-            return false;
-
-        if(type == 0) {
-            // boolean
-            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
-            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
-
-            // if the value matches any of the positive/negative possibilities
-            for(unsigned i = 0; i < 4; i++) {
-                if(parsedValue.compare(positive[i], true) == 0) {
-                    res = 1; //!OCLINT parameter reassignment
-                    return true;
-                }
-                if(parsedValue.compare(negative[i], true) == 0) {
-                    res = 0; //!OCLINT parameter reassignment
-                    return true;
-                }
-            }
-        } else {
-            // integer
-            // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
-            int theInt = std::atoi(parsedValue.c_str()); // NOLINT
-            if(theInt != 0) {
-                res = theInt; //!OCLINT parameter reassignment
-                return true;
-            }
+    bool seenBackslash = false;
+    const char* current = filtersString.c_str();
+    const char* end = current + strlen(current);
+    while(current != end) {
+      char character = *current++;
+      if(seenBackslash) {
+        seenBackslash = false;
+        if(character == ',' || character == '\\') {
+          s.put(character);
+          continue;
         }
-        return false;
+        s.put('\\');
+      }
+      if(character == '\\') {
+        seenBackslash = true;
+      } else if(character == ',') {
+        flush();
+      } else {
+        s.put(character);
+      }
     }
+
+    if(seenBackslash) {
+      s.put('\\');
+    }
+    flush();
+    return true;
+  }
+  return false;
+}
+
+enum optionType
+{
+  option_bool,
+  option_int
+};
+
+// parses an int/bool option from the command line
+bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
+                    int& res) {
+  String parsedValue;
+  if(!parseOption(argc, argv, pattern, &parsedValue))
+    return false;
+
+  if(type) {
+    // integer
+    // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
+    int theInt = std::atoi(parsedValue.c_str());
+    if (theInt != 0) {
+      res = theInt; //!OCLINT parameter reassignment
+      return true;
+    }
+  } else {
+    // boolean
+    const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
+    const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
+
+    // if the value matches any of the positive/negative possibilities
+    for (unsigned i = 0; i < 4; i++) {
+      if (parsedValue.compare(positive[i], true) == 0) {
+        res = 1; //!OCLINT parameter reassignment
+        return true;
+      }
+      if (parsedValue.compare(negative[i], true) == 0) {
+        res = 0; //!OCLINT parameter reassignment
+        return true;
+      }
+    }
+  }
+  return false;
+}
 } // namespace
 
 Context::Context(int argc, const char* const* argv)
-        : p(new detail::ContextState) {
-    parseArgs(argc, argv, true);
-    if(argc)
-        p->binary_name = argv[0];
+    : p(new detail::ContextState) {
+  parseArgs(argc, argv, true);
+  if(argc)
+    p->binary_name = argv[0];
 }
 
 Context::~Context() {
-    if(g_cs == p)
-        g_cs = nullptr;
-    delete p;
+  if(g_cs == p)
+    g_cs = nullptr;
+  delete p;
 }
 
 void Context::applyCommandLine(int argc, const char* const* argv) {
-    parseArgs(argc, argv);
-    if(argc)
-        p->binary_name = argv[0];
+  parseArgs(argc, argv);
+  if(argc)
+    p->binary_name = argv[0];
 }
 
 // parses args
 void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
-    using namespace detail;
+  using namespace detail;
 
-    // clang-format off
+  // clang-format off
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file=",        p->filters[0]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sf=",                 p->filters[0]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "source-file-exclude=",p->filters[1]);
@@ -5522,15 +6556,15 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "sce=",                p->filters[7]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "reporters=",          p->filters[8]);
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
-    // clang-format on
+  // clang-format on
 
-    int    intRes = 0;
-    String strRes;
+  int    intRes = 0;
+  String strRes;
 
 #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
     if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-        p->var = !!intRes;                                                                         \
+        p->var = static_cast<bool>(intRes);                                                        \
     else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
         p->var = true;                                                                             \
@@ -5550,7 +6584,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
        withDefaults)                                                                               \
     p->var = strRes
 
-    // clang-format off
+  // clang-format off
     DOCTEST_PARSE_STR_OPTION("out", "o", out, "");
     DOCTEST_PARSE_STR_OPTION("order-by", "ob", order_by, "file");
     DOCTEST_PARSE_INT_OPTION("rand-seed", "rs", rand_seed, 0);
@@ -5565,9 +6599,12 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
@@ -5576,48 +6613,50 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
-    // clang-format on
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
+  // clang-format on
 
-    if(withDefaults) {
-        p->help             = false;
-        p->version          = false;
-        p->count            = false;
-        p->list_test_cases  = false;
-        p->list_test_suites = false;
-        p->list_reporters   = false;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
-        p->help = true;
-        p->exit = true;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
-        p->version = true;
-        p->exit    = true;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
-        p->count = true;
-        p->exit  = true;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
-        p->list_test_cases = true;
-        p->exit            = true;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
-        p->list_test_suites = true;
-        p->exit             = true;
-    }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
-        p->list_reporters = true;
-        p->exit           = true;
-    }
+  if(withDefaults) {
+    p->help             = false;
+    p->version          = false;
+    p->count            = false;
+    p->list_test_cases  = false;
+    p->list_test_suites = false;
+    p->list_reporters   = false;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+    p->help = true;
+    p->exit = true;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+    p->version = true;
+    p->exit    = true;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+    p->count = true;
+    p->exit  = true;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+    p->list_test_cases = true;
+    p->exit            = true;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+    p->list_test_suites = true;
+    p->exit             = true;
+  }
+  if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+      parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+    p->list_reporters = true;
+    p->exit           = true;
+  }
 }
 
 // allows the user to add procedurally to the filters from the command line
@@ -5625,20 +6664,25 @@ void Context::addFilter(const char* filter, const char* value) { setOption(filte
 
 // allows the user to clear all filters from the command line
 void Context::clearFilters() {
-    for(auto& curr : p->filters)
-        curr.clear();
+  for(auto& curr : p->filters)
+    curr.clear();
 }
 
-// allows the user to override procedurally the int/bool options from the command line
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+  setOption(option, value ? "true" : "false");
+}
+
+// allows the user to override procedurally the int options from the command line
 void Context::setOption(const char* option, int value) {
-    setOption(option, toString(value).c_str());
+  setOption(option, toString(value).c_str());
 }
 
 // allows the user to override procedurally the string options from the command line
 void Context::setOption(const char* option, const char* value) {
-    auto argv   = String("-") + option + "=" + value;
-    auto lvalue = argv.c_str();
-    parseArgs(1, &lvalue);
+  auto argv   = String("-") + option + "=" + value;
+  auto lvalue = argv.c_str();
+  parseArgs(1, &lvalue);
 }
 
 // users should query this in their main() and exit the program if true
@@ -5648,279 +6692,311 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+  class : public std::streambuf
+  {
+  private:
+    // allowing some buffering decreases the amount of calls to overflow
+    char buf[1024];
+
+  protected:
+    std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+
+    int_type overflow(int_type ch) override {
+      setp(std::begin(buf), std::end(buf));
+      return traits_type::not_eof(ch);
+    }
+  } discardBuf;
+
+public:
+  DiscardOStream()
+      : std::ostream(&discardBuf) {}
+} discardOut;
+
 // the main function that does all the filtering and test running
 int Context::run() {
-    using namespace detail;
+  using namespace detail;
 
-    // save the old context state in case such was setup - for using asserts out of a testing context
-    auto old_cs = g_cs;
-    // this is the current contest
-    g_cs               = p;
-    is_running_in_test = true;
+  // save the old context state in case such was setup - for using asserts out of a testing context
+  auto old_cs = g_cs;
+  // this is the current contest
+  g_cs               = p;
+  is_running_in_test = true;
 
-    g_no_colors = p->no_colors;
-    p->resetRunData();
+  g_no_colors = p->no_colors;
+  p->resetRunData();
 
-    // stdout by default
-    p->cout = &std::cout;
-    p->cerr = &std::cerr;
-
-    // or to a file if specified
-    std::fstream fstr;
-    if(p->out.size()) {
-        fstr.open(p->out.c_str(), std::fstream::out);
-        p->cout = &fstr;
+  std::fstream fstr;
+  if(p->cout == nullptr) {
+    if(p->quiet) {
+      p->cout = &discardOut;
+    } else if(p->out.size()) {
+      // to a file if specified
+      fstr.open(p->out.c_str(), std::fstream::out);
+      p->cout = &fstr;
+    } else {
+      // stdout by default
+      p->cout = &std::cout;
     }
+  }
 
-    auto cleanup_and_return = [&]() {
-        if(fstr.is_open())
-            fstr.close();
+  FatalConditionHandler::allocateAltStackMem();
 
-        // restore context
-        g_cs               = old_cs;
-        is_running_in_test = false;
+  auto cleanup_and_return = [&]() {
+    FatalConditionHandler::freeAltStackMem();
 
-        // we have to free the reporters which were allocated when the run started
-        for(auto& curr : p->reporters_currently_used)
-            delete curr;
-        p->reporters_currently_used.clear();
+    if(fstr.is_open())
+      fstr.close();
 
-        if(p->numTestCasesFailed && !p->no_exitcode)
-            return EXIT_FAILURE;
-        return EXIT_SUCCESS;
-    };
+    // restore context
+    g_cs               = old_cs;
+    is_running_in_test = false;
 
-    // setup default reporter if none is given through the command line
-    if(p->filters[8].empty())
-        p->filters[8].push_back("console");
+    // we have to free the reporters which were allocated when the run started
+    for(auto& curr : p->reporters_currently_used)
+      delete curr;
+    p->reporters_currently_used.clear();
 
-    // check to see if any of the registered reporters has been selected
-    for(auto& curr : getReporters()) {
-        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
-            p->reporters_currently_used.push_back(curr.second(*g_cs));
-    }
+    if(p->numTestCasesFailed && !p->no_exitcode)
+      return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+  };
 
-    // TODO: check if there is nothing in reporters_currently_used
+  // setup default reporter if none is given through the command line
+  if(p->filters[8].empty())
+    p->filters[8].push_back("console");
 
-    // prepend all listeners
-    for(auto& curr : getListeners())
-        p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
+  // check to see if any of the registered reporters has been selected
+  for(auto& curr : getReporters()) {
+    if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+      p->reporters_currently_used.push_back(curr.second(*g_cs));
+  }
+
+  // TODO: check if there is nothing in reporters_currently_used
+
+  // prepend all listeners
+  for(auto& curr : getListeners())
+    p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(isDebuggerActive())
-        p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
+  if(isDebuggerActive() && p->no_debug_output == false)
+    p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
 #endif // DOCTEST_PLATFORM_WINDOWS
 
-    // handle version, help and no_run
-    if(p->no_run || p->version || p->help || p->list_reporters) {
-        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
-
-        return cleanup_and_return();
-    }
-
-    std::vector<const TestCase*> testArray;
-    for(auto& curr : getRegisteredTests())
-        testArray.push_back(&curr);
-    p->numTestCases = testArray.size();
-
-    // sort the collected records
-    if(!testArray.empty()) {
-        if(p->order_by.compare("file", true) == 0) {
-            std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
-        } else if(p->order_by.compare("suite", true) == 0) {
-            std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
-        } else if(p->order_by.compare("name", true) == 0) {
-            std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
-        } else if(p->order_by.compare("rand", true) == 0) {
-            std::srand(p->rand_seed);
-
-            // random_shuffle implementation
-            const auto first = &testArray[0];
-            for(size_t i = testArray.size() - 1; i > 0; --i) {
-                int idxToSwap = std::rand() % (i + 1); // NOLINT
-
-                const auto temp = first[i];
-
-                first[i]         = first[idxToSwap];
-                first[idxToSwap] = temp;
-            }
-        }
-    }
-
-    std::set<String> testSuitesPassingFilt;
-
-    bool                query_mode = p->count || p->list_test_cases || p->list_test_suites;
-    std::vector<String> queryResults;
-
-    if(!query_mode)
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
-
-    // invoke the registered functions if they match the filter criteria (or just count them)
-    for(auto& curr : testArray) {
-        const auto& tc = *curr;
-
-        bool skip_me = false;
-        if(tc.m_skip && !p->no_skip)
-            skip_me = true;
-
-        if(!matchesAny(tc.m_file, p->filters[0], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_file, p->filters[1], false, p->case_sensitive))
-            skip_me = true;
-        if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-            skip_me = true;
-        if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-            skip_me = true;
-
-        if(!skip_me)
-            p->numTestCasesPassingFilters++;
-
-        // skip the test if it is not in the execution range
-        if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-           (p->first > p->numTestCasesPassingFilters))
-            skip_me = true;
-
-        if(skip_me) {
-            if(!query_mode)
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
-            continue;
-        }
-
-        // do not execute the test if we are to only count the number of filter passing tests
-        if(p->count)
-            continue;
-
-        // print the name of the test and don't execute it
-        if(p->list_test_cases) {
-            queryResults.push_back(tc.m_name);
-            continue;
-        }
-
-        // print the name of the test suite if not done already and don't execute it
-        if(p->list_test_suites) {
-            if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                queryResults.push_back(tc.m_test_suite);
-                testSuitesPassingFilt.insert(tc.m_test_suite);
-                p->numTestSuitesPassingFilters++;
-            }
-            continue;
-        }
-
-        // execute the test if it passes all the filtering
-        {
-            p->currentTest = &tc;
-
-            p->failure_flags = TestCaseFailureReason::None;
-            p->seconds       = 0;
-
-            // reset atomic counters
-            p->numAssertsFailedCurrentTest_atomic = 0;
-            p->numAssertsCurrentTest_atomic       = 0;
-
-            p->subcasesPassed.clear();
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
-
-            p->timer.start();
-            
-            bool run_test = true;
-
-            do {
-                // reset some of the fields for subcases (except for the set of fully passed ones)
-                p->should_reenter          = false;
-                p->subcasesCurrentMaxLevel = 0;
-                p->subcasesStack.clear();
-
-                p->shouldLogCurrentException = true;
-
-                // reset stuff for logging with INFO()
-                p->stringifiedContexts.clear();
-
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                try {
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-                    FatalConditionHandler fatalConditionHandler; // Handle signals
-                    // execute the test
-                    tc.m_test();
-                    fatalConditionHandler.reset();
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                } catch(const TestFailureException&) {
-                    p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                } catch(...) {
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
-                                                      {translateActiveException(), false});
-                    p->failure_flags |= TestCaseFailureReason::Exception;
-                }
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-                // exit this loop if enough assertions have failed - even if there are more subcases
-                if(p->abort_after > 0 &&
-                   p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                    run_test = false;
-                    p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
-                }
-                
-                if(p->should_reenter && run_test)
-                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
-                if(!p->should_reenter)
-                    run_test = false;
-            } while(run_test);
-
-            p->finalizeTestCaseData();
-
-            DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
-
-            p->currentTest = nullptr;
-
-            // stop executing tests if enough assertions have failed
-            if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                break;
-        }
-    }
-
-    if(!query_mode) {
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
-    } else {
-        QueryData qdata;
-        qdata.run_stats = g_cs;
-        qdata.data      = queryResults.data();
-        qdata.num_data  = unsigned(queryResults.size());
-        DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
-    }
-
-    // see these issues on the reasoning for this:
-    // - https://github.com/onqtam/doctest/issues/143#issuecomment-414418903
-    // - https://github.com/onqtam/doctest/issues/126
-    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE
-        { std::cout << std::string(); };
-    DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS();
+  // handle version, help and no_run
+  if(p->no_run || p->version || p->help || p->list_reporters) {
+    DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, QueryData());
 
     return cleanup_and_return();
+  }
+
+  std::vector<const TestCase*> testArray;
+  for(auto& curr : getRegisteredTests())
+    testArray.push_back(&curr);
+  p->numTestCases = testArray.size();
+
+  // sort the collected records
+  if(!testArray.empty()) {
+    if(p->order_by.compare("file", true) == 0) {
+      std::sort(testArray.begin(), testArray.end(), fileOrderComparator);
+    } else if(p->order_by.compare("suite", true) == 0) {
+      std::sort(testArray.begin(), testArray.end(), suiteOrderComparator);
+    } else if(p->order_by.compare("name", true) == 0) {
+      std::sort(testArray.begin(), testArray.end(), nameOrderComparator);
+    } else if(p->order_by.compare("rand", true) == 0) {
+      std::srand(p->rand_seed);
+
+      // random_shuffle implementation
+      const auto first = &testArray[0];
+      for(size_t i = testArray.size() - 1; i > 0; --i) {
+        int idxToSwap = std::rand() % (i + 1);
+
+        const auto temp = first[i];
+
+        first[i]         = first[idxToSwap];
+        first[idxToSwap] = temp;
+      }
+    } else if(p->order_by.compare("none", true) == 0) {
+      // means no sorting - beneficial for death tests which call into the executable
+      // with a specific test case in mind - we don't want to slow down the startup times
+    }
+  }
+
+  std::set<String> testSuitesPassingFilt;
+
+  bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
+  std::vector<const TestCaseData*> queryResults;
+
+  if(!query_mode)
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
+
+  // invoke the registered functions if they match the filter criteria (or just count them)
+  for(auto& curr : testArray) {
+    const auto& tc = *curr;
+
+    bool skip_me = false;
+    if(tc.m_skip && !p->no_skip)
+      skip_me = true;
+
+    if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
+      skip_me = true;
+    if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
+      skip_me = true;
+    if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
+      skip_me = true;
+    if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
+      skip_me = true;
+    if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
+      skip_me = true;
+    if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
+      skip_me = true;
+
+    if(!skip_me)
+      p->numTestCasesPassingFilters++;
+
+    // skip the test if it is not in the execution range
+    if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+        (p->first > p->numTestCasesPassingFilters))
+      skip_me = true;
+
+    if(skip_me) {
+      if(!query_mode)
+        DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+      continue;
+    }
+
+    // do not execute the test if we are to only count the number of filter passing tests
+    if(p->count)
+      continue;
+
+    // print the name of the test and don't execute it
+    if(p->list_test_cases) {
+      queryResults.push_back(&tc);
+      continue;
+    }
+
+    // print the name of the test suite if not done already and don't execute it
+    if(p->list_test_suites) {
+      if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+        queryResults.push_back(&tc);
+        testSuitesPassingFilt.insert(tc.m_test_suite);
+        p->numTestSuitesPassingFilters++;
+      }
+      continue;
+    }
+
+    // execute the test if it passes all the filtering
+    {
+      p->currentTest = &tc;
+
+      p->failure_flags = TestCaseFailureReason::None;
+      p->seconds       = 0;
+
+      // reset atomic counters
+      p->numAssertsFailedCurrentTest_atomic = 0;
+      p->numAssertsCurrentTest_atomic       = 0;
+
+      p->fullyTraversedSubcases.clear();
+
+      DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
+
+      p->timer.start();
+
+      bool run_test = true;
+
+      do {
+        // reset some of the fields for subcases (except for the set of fully passed ones)
+        p->reachedLeaf = false;
+        // May not be empty if previous subcase exited via exception.
+        p->subcaseStack.clear();
+        p->currentSubcaseDepth = 0;
+
+        p->shouldLogCurrentException = true;
+
+        // reset stuff for logging with INFO()
+        p->stringifiedContexts.clear();
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        try {
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+          // MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
+          DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
+          FatalConditionHandler fatalConditionHandler; // Handle signals
+          // execute the test
+          tc.m_test();
+          fatalConditionHandler.reset();
+          DOCTEST_MSVC_SUPPRESS_WARNING_POP
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        } catch(const TestFailureException&) {
+          p->failure_flags |= TestCaseFailureReason::AssertFailure;
+        } catch(...) {
+          DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception,
+                                            {translateActiveException(), false});
+          p->failure_flags |= TestCaseFailureReason::Exception;
+        }
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+        // exit this loop if enough assertions have failed - even if there are more subcases
+        if(p->abort_after > 0 &&
+            p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
+          run_test = false;
+          p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
+        }
+
+        if(!p->nextSubcaseStack.empty() && run_test)
+          DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+        if(p->nextSubcaseStack.empty())
+          run_test = false;
+      } while(run_test);
+
+      p->finalizeTestCaseData();
+
+      DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
+
+      p->currentTest = nullptr;
+
+      // stop executing tests if enough assertions have failed
+      if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+        break;
+    }
+  }
+
+  if(!query_mode) {
+    DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
+  } else {
+    QueryData qdata;
+    qdata.run_stats = g_cs;
+    qdata.data      = queryResults.data();
+    qdata.num_data  = unsigned(queryResults.size());
+    DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
+  }
+
+  return cleanup_and_return();
 }
 
-IReporter::~IReporter() = default;
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
 int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
 const IContextScope* const* IReporter::get_active_contexts() {
-    return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
+  return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
 }
 
 int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
 const String* IReporter::get_stringified_contexts() {
-    return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
+  return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
 }
 
 namespace detail {
-    void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
-        if(isReporter)
-            getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-        else
-            getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
-    }
+void registerReporterImpl(const char* name, int priority, reporterCreatorFunc c, bool isReporter) {
+  if(isReporter)
+    getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+  else
+    getListeners().insert(reporterMap::value_type(reporterMap::key_type(priority, name), c));
+}
 } // namespace detail
 
 } // namespace doctest
@@ -5936,6 +7012,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
 #endif // DOCTEST_LIBRARY_IMPLEMENTATION
 #endif // DOCTEST_CONFIG_IMPLEMENT

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -138,7 +138,33 @@ TEST_CASE("unicode::display_width correctly returns the display width of unicode
     }
 
     {
-        // Woman scientist emoji
+        // smiley emoji
+        const std::string input  = u8"😁";
+        const auto result = unicode::display_width(input);
+        REQUIRE(result == 2);
+        print_columns(input, result);
+    }
+
+    {
+        // zero-width-joiner ZWJ
+        const std::string input = u8"‍";
+        const auto result = unicode::display_width(input);
+        REQUIRE(result == 0);
+        print_columns(input, result);
+    }
+
+    {
+        // Woman scientist emoji - explicit version
+        // i.e. Woman emoji + zero-width-joiner (‍) + microscope emoji
+        const std::string input = u8"👩\u200D🔬";
+        REQUIRE(input == u8"👩‍🔬");
+        const auto result = unicode::display_width(input);
+        REQUIRE(result == 2);
+        print_columns(input, result);
+    }
+
+    {
+        // Woman scientist emoji - implicit version
         const std::string input = u8"👩‍🔬";
         const auto result = unicode::display_width(input);
         REQUIRE(result == 2);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -233,4 +233,12 @@ TEST_CASE("unicode::display_width correctly returns the display width of unicode
         const auto result = unicode::display_width(input);
         REQUIRE(result == 17);
     }
+
+    {
+        // ANSI escape characters wrapping a red and (blinking) green 'XX'
+        const std::string input = "\x1b[31mX\x1b[23;32mX\x1b[0m";
+        const auto result = unicode::display_width(input);
+        REQUIRE(result == 2);
+        print_columns(input, result);
+    }
 }


### PR DESCRIPTION
Found this neat little head-only library that nearly fully fitted my purpose.  @p-ranav thanks for sharing! :+1:

* **added support for zero-width-joiner**:
  fixes support for both basic 😁 and combined 👩‍🔬 emojis.
  e.g. the latter are actually three characters that are joined:
  a Woman emoji + a zero-width-joiner (‍) + a microscope emoji
  see also: https://en.wikipedia.org/wiki/Zero-width_joiner

* **added support for ANSI escape sequences**:
   usually of the form of "\x1b[31m" (here: red), to be formatted text, and enclosing "\x1b[0m" sequence to reset the state.
   Most are zero length except cursor control sequences.
   a good summary can be found [here](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797)

A simple compiler-explorer demo can be seen [here](https://compiler-explorer.com/z/x34KM1shM):
```text
'XX'	-> byte 19 vs. visible length unicode: 2 fmt: 19
'😀'	-> byte  4 vs. visible length unicode: 2 fmt: 2
'👩‍🔬'	-> byte 11 vs. visible length unicode: 2 fmt: 5
```

N.B. needed to also upgrade doctest and the header-guards to be compatible with more modern compilers without warning.